### PR TITLE
More explicit install instructions in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,14 +11,14 @@ Dependencies
 
 bpython-curtsies
 ----------------
-``bpython-curtsies`` requires the following additional packages:
+``bpython-curtsies`` requires the following additional packages: (`pip install bpython[curtsies]`)
 
-* curtsies >= 0.1.0
+* curtsies (bpython 0.13 requires curtsies <0.1.0, master requires >=0.1.0)
 * greenlet
 
 bpython-urwid
 -------------
-``bpython-urwid`` requires the following additional packages:
+``bpython-urwid`` requires the following additional packages: (`pip install bpython[urwid]`)
 
 * urwid
 


### PR DESCRIPTION
I'd like
- warn people about the different curtsies versions
- tell people how about `pip install bpython[curtsies]` optional dependencies syntax
