### PR TITLE
reload modules with F6 - fix #285

### DIFF
--- a/bpython/config.py
+++ b/bpython/config.py
@@ -80,6 +80,7 @@ def loadini(struct, configfile):
             'show_source': 'F2',
             'suspend': 'C-z',
             'undo': 'C-r',
+            'reimport': 'F6',
             'search': 'C-o',
             'up_one_line': 'C-p',
             'yank_from_buffer': 'C-y'},
@@ -120,6 +121,7 @@ def loadini(struct, configfile):
     struct.show_source_key = config.get('keyboard', 'show_source')
     struct.suspend_key = config.get('keyboard', 'suspend')
     struct.undo_key = config.get('keyboard', 'undo')
+    struct.reimport_key = config.get('keyboard', 'reimport')
     struct.up_one_line_key = config.get('keyboard', 'up_one_line')
     struct.down_one_line_key = config.get('keyboard', 'down_one_line')
     struct.cut_to_buffer_key = config.get('keyboard', 'cut_to_buffer')

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -406,7 +406,7 @@ class Repl(BpythonRepl):
             self.on_tab()
         elif e in ("KEY_BTAB",): # shift-tab
             self.on_tab(back=True)
-        elif e in ("KEY_F(6)",):
+        elif e in key_dispatch[self.config.reimport_key]:
             self.clear_modules_and_reevaluate()
             self.update_completion()
         elif e in key_dispatch[self.config.undo_key]: #ctrl-r for undo

--- a/doc/sphinx/source/configuration-options.rst
+++ b/doc/sphinx/source/configuration-options.rst
@@ -167,6 +167,14 @@ Default: F9
 
 Shows the last output in the systems $PAGER.
 
+reimport
+^^^^^^^^
+Default: F6
+
+Reruns entire session, reloading all modules by clearing the sys.modules cache.
+
+.. versionadded:: 0.14
+
 save
 ^^^^
 Default: C-s


### PR DESCRIPTION
Key that clears the `sys.modules` cache of modules and reevaluates session.
