### PR TITLE
Backround

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -275,6 +275,7 @@ class Repl(BpythonRepl):
         sys.stdin = self.stdin
         self.orig_sigwinch_handler = signal.getsignal(signal.SIGWINCH)
         signal.signal(signal.SIGWINCH, self.sigwinch_handler)
+        self.orig_sigtstp_handler = signal.getsignal(signal.SIGTSTP)
         signal.signal(signal.SIGTSTP, lambda *args: None)
         return self
 
@@ -282,6 +283,7 @@ class Repl(BpythonRepl):
         sys.stdin = self.orig_stdin
         sys.stdout = self.orig_stdout
         sys.stderr = self.orig_stderr
+        signal.signal(signal.SIGTSTP, self.orig_sigtstp_handler)
         signal.signal(signal.SIGWINCH, self.orig_sigwinch_handler)
 
     def sigwinch_handler(self, signum, frame):


### PR DESCRIPTION
Not sure if this is actually an improvement - just prevents user from suspending and then backgrounding bpython-curtsies because it won't foreground very well afterwards.
