### PR TITLE
Fixed #341 right arrow suggestion color

### DIFF
--- a/bpython/config.py
+++ b/bpython/config.py
@@ -178,6 +178,7 @@ def loadini(struct, configfile):
             'paren': 'R',
             'prompt': 'c',
             'prompt_more': 'g',
+            'right_arrow_suggestion': 'K',
         }
 
     if color_scheme_name == 'default':

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -948,7 +948,8 @@ class Repl(BpythonRepl):
     @property
     def current_cursor_line(self):
         if self.config.curtsies_right_arrow_completion:
-            return self.current_cursor_line_without_suggestion + fmtfuncs.bold(fmtfuncs.dark((self.current_suggestion)))
+            return (self.current_cursor_line_without_suggestion +
+                func_for_letter(self.config.color_scheme['right_arrow_suggestion'])(self.current_suggestion))
         else:
             return self.current_cursor_line_without_suggestion
 

--- a/doc/sphinx/source/themes.rst
+++ b/doc/sphinx/source/themes.rst
@@ -38,6 +38,7 @@ Available Switches
 * main
 * prompt
 * prompt_more
+* right_arrow_suggestion
 
 Default Theme
 -------------
@@ -74,6 +75,7 @@ The default theme included in bpython is as follows:
   main = c
   prompt = c
   prompt_more = g
+  right_arrow_suggestion = K
 
 .. :: Footnotes
 

--- a/light.theme
+++ b/light.theme
@@ -26,3 +26,4 @@ output = b
 main = b
 prompt = r
 prompt_more = g
+right_arrow_suggestion = K

--- a/sample.theme
+++ b/sample.theme
@@ -27,3 +27,4 @@ output = w
 main = c
 prompt = c
 prompt_more = g
+right_arrow_suggestion = K


### PR DESCRIPTION
- Added `right_arrow_suggestion` to configuration ('K' by default)
- Use the configured colour instead of hardcoded colour
- Updated docs and themes
