### PR TITLE
Fixed #284

### DIFF
--- a/bpython/args.py
+++ b/bpython/args.py
@@ -90,6 +90,7 @@ def parse(args, extras=None, ignore_stdin=False):
 
     if not ignore_stdin and not (sys.stdin.isatty() and sys.stdout.isatty()):
         interpreter = code.InteractiveInterpreter()
+        print "Entering st.read %s" % sys.stdout.isatty()
         interpreter.runsource(sys.stdin.read())
         raise SystemExit
 
@@ -107,5 +108,6 @@ def exec_code(interpreter, args):
         source = sourcefile.read()
     old_argv, sys.argv = sys.argv, args
     sys.path.insert(0, os.path.abspath(os.path.dirname(args[0])))
+    interpreter.locals['__file__'] = args[0]
     interpreter.runsource(source, args[0], 'exec')
     sys.argv = old_argv

--- a/bpython/test/test_args.py
+++ b/bpython/test/test_args.py
@@ -1,0 +1,20 @@
+import unittest
+import subprocess
+import tempfile
+import sys
+
+
+
+
+class TestExecArgs(unittest.TestCase):
+    def test_exec_dunder_file(self):
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(
+            "import sys; print 'hello'; sys.stderr.write(__file__); sys.stderr.flush();")
+            f.flush()
+            print open(f.name).read()
+            p = subprocess.Popen(['bpython-curtsies', f.name], stderr= subprocess.PIPE)
+            
+            self.assertEquals(p.stderr.read().strip(), f.name)
+
+


### PR DESCRIPTION
When a file is being run from command line, we added **file** to the namespace. The test is calling a subprocess (bpython-curtsies). Test will fails when calling bpython instead of bpython-curtsies because of stderr redirection (#408).
