### PR TITLE
fix bpython-curtsies crashes if no readline history on enter #432

### DIFF
--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -238,7 +238,7 @@ class History(object):
         """Move forward to the end of the history."""
         if not self.is_at_start:
             self.index = 0
-        return self.entries[0]
+        return self.entries[0] if self.entries else ''
 
     @property
     def is_at_end(self):

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -75,6 +75,13 @@ class TestHistory(unittest.TestCase):
         self.assertTrue(self.history.is_at_start)
         self.assertFalse(self.history.is_at_end)
 
+    def test_last_with_no_history_doesnt_throw_error(self):
+        self.history = repl.History([])
+        try:
+            self.history.last()
+        except IndexError:
+            self.fail("should not throw error if history is empty")
+
     def test_back(self):
         self.assertEqual(self.history.back(), '#999')
         self.assertNotEqual(self.history.back(), '#999')


### PR DESCRIPTION
It actually works correctly if there is no existing history the first time you press enter. But then insert_into_history sets entries to [] and tries to read from the history file, which will do nothing if the history file is empty.

This is fixed properly on master, for now just change last() to return an empty string if history entries are empty.