### PR TITLE
Refactor and fix keybinding issue (fixes #447)

### DIFF
--- a/bpython/config.py
+++ b/bpython/config.py
@@ -74,7 +74,6 @@ def loadini(struct, configfile):
             'transpose_chars': 'C-t',
             'clear_line': 'C-u',
             'clear_screen': 'C-l',
-            'kill_line': 'C-k',
             'clear_word': 'C-w',
             'cut_to_buffer': 'C-k',
             'delete': 'C-d',
@@ -172,7 +171,6 @@ def loadini(struct, configfile):
     struct.transpose_chars_key = get_key_no_doublebind('transpose_chars')
     struct.clear_line_key = get_key_no_doublebind('clear_line')
     struct.clear_screen_key = get_key_no_doublebind('clear_screen')
-    struct.kill_line_key = get_key_no_doublebind('kill_line')
     struct.exit_key = get_key_no_doublebind('exit')
     struct.last_output_key = get_key_no_doublebind('last_output')
     struct.edit_config_key = get_key_no_doublebind('edit_config')

--- a/bpython/config.py
+++ b/bpython/config.py
@@ -104,6 +104,39 @@ def loadini(struct, configfile):
             'list_above' : False,
             'right_arrow_completion' : True,
         }}
+
+    default_keys_to_commands = {
+        '': 'exit',
+        'C-n': 'down_one_line',
+        'C-l': 'clear_screen',
+        'C-k': 'kill_line',
+        'C-o': 'search',
+        'C-h': 'backspace',
+        'C-f': 'right',
+        'C-e': 'end_of_line',
+        'C-d': 'delete',
+        'C-b':'left',
+        'C-a': 'beginning_of_line',
+        'C-z': 'suspend',
+        'C-y': 'yank_from_buffer',
+        'C-x': 'edit_current_block',
+        'C-w': 'clear_word',
+        'C-u': 'clear_line',
+        'C-t': 'transpose_chars',
+        'C-s': 'save',
+        'C-r': 'undo',
+        'C-p': 'up_one_line',
+        'F10': 'copy_clipboard',
+        'F1': 'help',
+        'F2': 'show_source',
+        'F3': 'edit_config',
+        'F5': 'toggle_file_watch',
+        'F6': 'reimport',
+        'F7': 'external_editor',
+        'F8': 'pastebin',
+        'F9': 'last_output'
+    }
+
     fill_config_with_default_values(config, defaults)
     if not config.read(config_path):
         # No config file. If the user has it in the old place then complain
@@ -113,17 +146,17 @@ def loadini(struct, configfile):
                              "%s\n" % default_config_path())
             sys.exit(1)
 
-    def get_key_no_doublebind(attr, already_used={}):
-        """Clears any other configured keybindings using this key"""
-        key = config.get('keyboard', attr)
-        if key in already_used:
-            default = defaults['keyboard'][already_used[key]]
-            if default in already_used:
-                setattr(struct, '%s_key' % already_used[key], '')
-            else:
-                setattr(struct, '%s_key' % already_used[key], default)
-        already_used[key] = attr
-        return key
+
+    def get_key_no_doublebind(command):
+        default_commands_to_keys = defaults['keyboard']
+        requested_key = config.get('keyboard', command)
+        default_command = default_keys_to_commands[requested_key]
+
+        if default_commands_to_keys[default_command] == \
+           config.get('keyboard', default_command):
+            setattr(struct, '%s_key' % default_command, '')
+
+        return requested_key
 
     struct.config_path = config_path
 

--- a/bpython/config.py
+++ b/bpython/config.py
@@ -105,37 +105,8 @@ def loadini(struct, configfile):
             'right_arrow_completion' : True,
         }}
 
-    default_keys_to_commands = {
-        '': 'exit',
-        'C-n': 'down_one_line',
-        'C-l': 'clear_screen',
-        'C-k': 'kill_line',
-        'C-o': 'search',
-        'C-h': 'backspace',
-        'C-f': 'right',
-        'C-e': 'end_of_line',
-        'C-d': 'delete',
-        'C-b':'left',
-        'C-a': 'beginning_of_line',
-        'C-z': 'suspend',
-        'C-y': 'yank_from_buffer',
-        'C-x': 'edit_current_block',
-        'C-w': 'clear_word',
-        'C-u': 'clear_line',
-        'C-t': 'transpose_chars',
-        'C-s': 'save',
-        'C-r': 'undo',
-        'C-p': 'up_one_line',
-        'F10': 'copy_clipboard',
-        'F1': 'help',
-        'F2': 'show_source',
-        'F3': 'edit_config',
-        'F5': 'toggle_file_watch',
-        'F6': 'reimport',
-        'F7': 'external_editor',
-        'F8': 'pastebin',
-        'F9': 'last_output'
-    }
+    default_keys_to_commands = dict((value, key) for (key, value)
+                                    in defaults['keyboard'].iteritems())
 
     fill_config_with_default_values(config, defaults)
     if not config.read(config_path):

--- a/bpython/curtsiesfrontend/manual_readline.py
+++ b/bpython/curtsiesfrontend/manual_readline.py
@@ -250,7 +250,7 @@ def delete_line(cursor_offset, line):
 def uppercase_next_word(cursor_offset, line):
     return cursor_offset, line #TODO Not implemented
 
-@edit_keys.on(config='kill_line_key')
+@edit_keys.on(config='cut_to_buffer_key')
 @kills_ahead
 def delete_from_cursor_forward(cursor_offset, line):
     return cursor_offset, line[:cursor_offset], line[cursor_offset:]


### PR DESCRIPTION
This changes the logic for the function `get_key_no_doublebind()` and removes the mutable list which was previously used to keep track of keybindings which were already assigned. Although this fix passes the test cases and the specific case mentioned in #447, the logic is such that specifying the same custom keybinding for two commands will result in only one command being bound. Also I am getting 12 skipped tests when running nosetests, any ideas why this is happening?

With:
`help = F9`
`show_source = F9`

F9  is mapped to `show_source` and `help` is not mapped to any key. I think this is because the keybindings are assigned sequentially so because `show_source` is assigned first (line 182) vs `help` (line 210).

I think this is still a substantial improvement over the old code because it is easier to understand and has more functionality than before. Although the problem of correctly handling custom keybinding is not completely resolved. Knowing the exact desired functionality would be helpful though.