### PR TITLE
Add feature to enable debugging on uncaught exceptions.

### DIFF
--- a/bpython/args.py
+++ b/bpython/args.py
@@ -74,6 +74,10 @@ def parse(args, extras=None, ignore_stdin=False):
                       help=_("Don't flush the output to stdout."))
     parser.add_option('--version', '-V', action='store_true',
                       help=_('Print version and exit.'))
+    parser.add_option('--pretty', '-p', action='store_true',
+                      help=_('Pretty print output.'))
+    parser.add_option('--debugger', '-D', action='store_true',
+                      help=_('Enter a debugger on exceptions.'))
 
     if extras is not None:
         extras_group = OptionGroup(parser, extras[0], extras[1])

--- a/bpython/args.py
+++ b/bpython/args.py
@@ -74,8 +74,6 @@ def parse(args, extras=None, ignore_stdin=False):
                       help=_("Don't flush the output to stdout."))
     parser.add_option('--version', '-V', action='store_true',
                       help=_('Print version and exit.'))
-    parser.add_option('--pretty', '-p', action='store_true',
-                      help=_('Pretty print output.'))
     parser.add_option('--debugger', '-D', action='store_true',
                       help=_('Enter a debugger on exceptions.'))
 

--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -81,6 +81,12 @@ from bpython.keys import cli_key_dispatch as key_dispatch
 from bpython import translations
 from bpython.translations import _
 
+# Debugging support
+try:
+    from bpython import debugger
+except ImportError as err:
+    debugger = None
+
 from bpython import repl
 from bpython._py3compat import py3
 from bpython.pager import page
@@ -959,6 +965,11 @@ class CLIRepl(repl.Repl):
             return ''
 
         elif key in key_dispatch[config.debug_key]:
+            if debugger is None:
+                self.echo(
+                    "\x01y\x03No debugger, check your PYTHON_DEBUGGER value.\n",
+                    )
+                return
             if sys.excepthook is not debugger_hook:
                 sys.excepthook = debugger_hook
             else:
@@ -1960,7 +1971,6 @@ def debugger_hook(exc, value, tb):
         return
 
     global stdscr
-    from bpython import debugger
 
     orig_stdin = sys.stdin
     orig_stdout = sys.stdout
@@ -1997,7 +2007,7 @@ def main(args=None, locals_=None, banner=None):
     orig_stdout = sys.stdout
     orig_stderr = sys.stderr
 
-    if options.debugger:
+    if options.debugger and debugger is not None:
         sys.excepthook = debugger_hook
 
     try:

--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -49,7 +49,6 @@ import math
 import re
 import time
 import functools
-from pprint import pprint
 
 import struct
 if platform.system() != 'Windows':
@@ -1954,10 +1953,6 @@ def main_curses(scr, args, config, interactive=True, locals_=None,
     return (exit_value, clirepl.getstdout())
 
 
-def prettydisplayhook(obj):
-    pprint(obj)
-
-
 def debugger_hook(exc, value, tb):
 
     if exc in (SyntaxError, IndentationError, KeyboardInterrupt):
@@ -2004,8 +1999,6 @@ def main(args=None, locals_=None, banner=None):
 
     if options.debugger:
         sys.excepthook = debugger_hook
-    if options.pretty:
-        sys.displayhook = prettydisplayhook
 
     try:
         (exit_value, output) = curses_wrapper(

--- a/bpython/config.py
+++ b/bpython/config.py
@@ -98,6 +98,7 @@ def loadini(struct, configfile):
             'clear_word': 'C-w',
             'copy_clipboard': 'F10',
             'cut_to_buffer': 'C-k',
+            'debug': 'F12',
             'delete': 'C-d',
             'down_one_line': 'C-n',
             'edit_config': 'F3',
@@ -120,7 +121,6 @@ def loadini(struct, configfile):
             'undo': 'C-r',
             'up_one_line': 'C-p',
             'yank_from_buffer': 'C-y',
-            'debug': 'F12',
         },
         'cli': {
             'suggestion_width': 0.8,

--- a/bpython/config.py
+++ b/bpython/config.py
@@ -119,7 +119,8 @@ def loadini(struct, configfile):
             'transpose_chars': 'C-t',
             'undo': 'C-r',
             'up_one_line': 'C-p',
-            'yank_from_buffer': 'C-y'
+            'yank_from_buffer': 'C-y',
+            'debug': 'F12',
         },
         'cli': {
             'suggestion_width': 0.8,
@@ -207,6 +208,7 @@ def loadini(struct, configfile):
     struct.edit_current_block_key = get_key_no_doublebind('edit_current_block')
     struct.external_editor_key = get_key_no_doublebind('external_editor')
     struct.help_key = get_key_no_doublebind('help')
+    struct.debug_key = get_key_no_doublebind('debug')
 
     struct.pastebin_confirm = config.getboolean('general', 'pastebin_confirm')
     struct.pastebin_url = config.get('general', 'pastebin_url')

--- a/bpython/debugger.py
+++ b/bpython/debugger.py
@@ -21,7 +21,7 @@ post_mortem = None
 
 def _get_debugger():
     global post_mortem
-    modname = os.environ.get("PYTHON_DEBUGGER", "pdb")
+    modname = os.environ.get("PYTHON_DEBUGGER", "bpdb")
     __import__(modname)
     mod = sys.modules[modname]
     pm = getattr(mod, "post_mortem")

--- a/bpython/debugger.py
+++ b/bpython/debugger.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
+# vim:ts=4:sw=4:softtabstop=4:smarttab:expandtab
+
+"""
+Debugger factory. Set PYTHON_DEBUGGER to a module path that has a post_mortem
+function in it. Defaults to pdb. This allows alternate debuggers to be used,
+such as pycopia.debugger. :)
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+
+import os
+import sys
+
+
+post_mortem = None
+
+def _get_debugger():
+    global post_mortem
+    modname = os.environ.get("PYTHON_DEBUGGER", "pdb")
+    __import__(modname)
+    mod = sys.modules[modname]
+    pm = getattr(mod, "post_mortem")
+    if pm.__code__.co_argcount > 2:
+        post_mortem = pm
+    else:
+        def _post_mortem(t, ex, exval):
+            return pm(t)
+        post_mortem = _post_mortem
+
+_get_debugger()
+

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -161,9 +161,15 @@ class Interpreter(code.InteractiveInterpreter):
                 l.insert(0, "Traceback (most recent call last):\n")
             l[len(l):] = traceback.format_exception_only(t, v)
         finally:
-            tblist = tb = None
+            tblist = None
+        # If someone has set sys.excepthook, we let that take precedence
+        # over self.write
+        if sys.excepthook is sys.__excepthook__:
+            tb = None
+            self.writetb(l)
+        else:
+            sys.excepthook(t, v, tb)
 
-        self.writetb(l)
 
     def writetb(self, lines):
         """This outputs the traceback and should be overridden for anything


### PR DESCRIPTION
The debugger is selected by an environment variable, PYTHON_DEBUGGER. This
should be set to a module path. If it's not set it will use the standard pdb.

Press F12 to toggle the feature off and on. When off the original behaviour is
used.

Also add pretty-printing option. Currently this is only selected when invoked
from the CLI.
