### PR TITLE
Fix Attribute error if matches_iter has not been initialised.

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -454,6 +454,8 @@ class CLIRepl(repl.Repl):
         Called whenever these should be updated, and called
         with tab
         """
+        super(CLIRepl,self).complete(tab)
+
         if self.paste_mode:
             self.scr.touchwin() #TODO necessary?
             return


### PR DESCRIPTION
I use bpython to provide CLI access to my database -style app (MysteryMachine ) , 

when entering a expression such as

```
obj['attribute'].get_root()
```

When I enter the opening bracket I get the following stack trace and bpython exits.

```
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 1961, in main
    banner=banner)
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 1843, in curses_wrapper
    return func(stdscr, *args, **kwargs)
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 1928, in main_curses
    exit_value = clirepl.repl()
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 1126, in repl
    inp = self.get_line()
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 670, in get_line
    if self.p_key(key) is None:
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 1021, in p_key
    self.addstr(key)
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 369, in addstr
    self.complete()
  File "/path/to/virtualenv/local/lib/python2.7/site-packages/bpython-0.14.1-py2.7.egg/bpython/cli.py", line 464, in complete
    self.show_list(self.matches_iter.matches, topline=self.argspec, formatter=self.matches_iter.completer.format)
AttributeError: 'NoneType' object has no attribute 'format'
```


Unfortunately I can't reprodcue it outside of my app, so I might have got soemthing else wrong , but it the attached pull requests fixes it and mackes sense to me - it seem odd that when the curses layer handles a completion event it doesn't re-run the match code in cli.CLI .

