### PR TITLE
Add Ctrl-e to complete current suggestion.

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -594,12 +594,11 @@ class Repl(BpythonRepl):
         if self.stdin.has_focus:
             return self.stdin.process_event(e)
 
-        if (e in ("<RIGHT>", '<Ctrl-f>') and
+        if (e in ("<RIGHT>", '<Ctrl-f>', '<Ctrl-e>') and
                 self.config.curtsies_right_arrow_completion and
                 self.cursor_offset == len(self.current_line)):
             self.current_line += self.current_suggestion
             self.cursor_offset = len(self.current_line)
-
         elif e in ("<UP>",) + key_dispatch[self.config.up_one_line_key]:
             self.up_one_line()
         elif e in ("<DOWN>",) + key_dispatch[self.config.down_one_line_key]:


### PR DESCRIPTION
This PR adds Ctrl-e to select the current suggestion in the curtsies frontend.

I love how the curtsies front-end shows completions from the history as I type. In order to complete that current suggestion I have to press 'Right-Arrow' or 'Ctrl-f'. I presume this is inspired by fish shell. Fish shell also allows Ctrl-e to select the current suggestion and this PR adds that behavior to bpython. 