### PR TITLE
completion matches in the middle of words

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -557,4 +557,4 @@ def _callable_postfix(value, word):
 
 
 def method_match(word, size, text):
-    return word[:size] == text
+    return text in word


### PR DESCRIPTION
May be related to issue #336.

It gives matches without the need to start with typed chars.

For exemple:

```
a = dict()
a.op   # will match "copy" and "pop"
```

I find strange that autocomplete_mode just doesn't work. Can someone explain me what is the purpose of this option now?