### PR TITLE
Load virtualenv if detected

### DIFF
--- a/bpython/args.py
+++ b/bpython/args.py
@@ -75,6 +75,10 @@ def parse(args, extras=None, ignore_stdin=False):
                       help=_("Don't flush the output to stdout."))
     parser.add_option('--version', '-V', action='store_true',
                       help=_('Print version and exit.'))
+    parser.add_option('--virtualenv', action='store_true', default=True,
+	    help=_('Load virtualenv if found (default: %default).'))
+    parser.add_option('--no-virtualenv', dest='virtualenv',
+	    action='store_false', help=_('Do *not* load virtualenv if found.'))
 
     if extras is not None:
         extras_group = OptionGroup(parser, extras[0], extras[1])
@@ -94,6 +98,14 @@ def parse(args, extras=None, ignore_stdin=False):
         print('(C) 2008-2015 Bob Farrell, Andreas Stuehrk et al. '
               'See AUTHORS for detail.')
         raise SystemExit
+
+    if options.virtualenv and os.environ.get('VIRTUAL_ENV'):
+        virtualenv_init = os.path.join(os.environ['VIRTUAL_ENV'], 'bin/activate_this.py')
+        try:
+            execfile(virtualenv_init, dict(__file__=virtualenv_init))
+        except Exception:
+            sys.stderr.write('Unable to load virtualenv %r\n' % os.path.basename(os.environ['VIRTUAL_ENV']))
+            raise
 
     if not ignore_stdin and not (sys.stdin.isatty() and sys.stdout.isatty()):
         interpreter = code.InteractiveInterpreter()


### PR DESCRIPTION
Hi,

this patch allow a **system-wide** installation of `bpython` to run a virtualenv; ie:

```console
user@darkstar:~$ type bpython
bpython is hashed (/usr/local/bin/bpython)
user@darkstar:~$ workon sandbox
(sandbox)user@darkstar:~$ bpython
```
```python
bpython version 0.15.dev115 on top of Python 2.7.3 /usr/bin/python
>>> import sys
>>> sys.real_prefix # see: http://stackoverflow.com/a/1883251/248390
'/usr'
>>> sys.path
['', '/home/user/.virtualenvs/sandbox/lib/python2.7/site-packages', ...]
```

Automatic loading of the virtualenv may be disabled with: `--no-virtualenv`.

I humbly think this feature is desired by the community.