### PR TITLE
Refactoring named tuple

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -127,9 +127,10 @@ class BaseCompletionType(object):
 
     def substitute(self, cursor_offset, line, match):
         """Returns a cursor offset and line with match swapped in"""
-        lpart =  self.locate(cursor_offset, line)
-        result = lpart.start + len(match), line[:lpart.start] + match + line[lpart.end:]
-        return result
+        lpart = self.locate(cursor_offset, line)
+        offset = lpart.start + len(match)
+        changed_line = line[:lpart.start] + match + line[lpart.end:]
+        return offset, changed_line
 
     @property
     def shown_before_tab(self):
@@ -401,7 +402,8 @@ class GlobalCompletion(BaseCompletionType):
                 # if identifier isn't ascii, don't complete (syntax error)
                 if word is None:
                     continue
-                if self.method_match(word, n, r.word) and word != "__builtins__":
+                if (self.method_match(word, n, r.word) and
+                        word != "__builtins__"):
                     matches.add(_callable_postfix(val, word))
         return matches
 

--- a/bpython/curtsiesfrontend/replpainter.py
+++ b/bpython/curtsiesfrontend/replpainter.py
@@ -157,13 +157,14 @@ def formatted_docstring(docstring, columns, config):
                 for line in docstring.split('\n')), [])
 
 
-def paint_infobox(rows, columns, matches, funcprops, arg_pos, match, docstring, config,
-                  format):
+def paint_infobox(rows, columns, matches, funcprops, arg_pos, match, docstring,
+                  config, format):
     """Returns painted completions, funcprops, match, docstring etc."""
     if not (rows and columns):
         return fsarray(0, 0)
     width = columns - 4
-    lines = ((formatted_argspec(funcprops, arg_pos, width, config) if funcprops else []) +
+    lines = ((formatted_argspec(funcprops, arg_pos, width, config)
+              if funcprops else []) +
              (matches_lines(rows, width, matches, match, config, format)
               if matches else []) +
              (formatted_docstring(docstring, width, config)

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -42,7 +42,7 @@ if not py3:
     _name = LazyReCompile(r'[a-zA-Z_]\w*$')
 
 ArgSpec = namedtuple('ArgSpec', ['args', 'varargs', 'varkwargs',  'defaults',
-                        'kwonly', 'kwonly_defaults', 'annotations'])
+                                 'kwonly', 'kwonly_defaults', 'annotations'])
 
 FuncProps = namedtuple('FuncProps', ['func', 'argspec', 'is_bound_method'])
 
@@ -240,7 +240,7 @@ def getfuncprops(func, f):
         argspec = list(argspec)
         fixlongargs(f, argspec)
         if len(argspec) == 4:
-            argspec = argspec + [list(),dict(),None]
+            argspec = argspec + [list(), dict(), None]
         argspec = ArgSpec(*argspec)
         fprops = FuncProps(func, argspec, is_bound_method)
     except (TypeError, KeyError):

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -469,8 +469,8 @@ class Repl(object):
 
     def get_args(self):
         """Check if an unclosed parenthesis exists, then attempt to get the
-        argspec() for it. On success, update self.funcprops,self.arg_pos and return True,
-        otherwise set self.funcprops to None and return False"""
+        argspec() for it. On success, update self.funcprops,self.arg_pos and
+        return True, otherwise set self.funcprops to None and return False"""
 
         self.current_func = None
 


### PR DESCRIPTION
Introduced three namedtuples along with associated refactoring
LinePart - Representing a word and its location in the interpreter input
FuncProps - Replaces the current argspec which contained function specific info along with Arg info. 
Argspec - Newly defined Argspec representing python2 and python3 argspec result from the inspect.getargspec()
