### PR TITLE
Transpose characters if cursor is at the end of the line

### DIFF
--- a/bpython/curtsiesfrontend/manual_readline.py
+++ b/bpython/curtsiesfrontend/manual_readline.py
@@ -280,8 +280,10 @@ def yank_prev_killed_text(cursor_offset, line, cut_buffer):
 
 @edit_keys.on(config='transpose_chars_key')
 def transpose_character_before_cursor(cursor_offset, line):
-    if cursor_offset == 0:
+    if cursor_offset < 2:
         return cursor_offset, line
+    if cursor_offset == len(line):
+        return cursor_offset, line[:-2] + line[-1] + line[-2]
     return (min(len(line), cursor_offset + 1),
             line[:cursor_offset - 1] +
             (line[cursor_offset] if len(line) > cursor_offset else '') +

--- a/bpython/test/test_manual_readline.py
+++ b/bpython/test/test_manual_readline.py
@@ -207,9 +207,15 @@ class TestManualReadline(unittest.TestCase):
 
     def test_transpose_first_character(self):
         self.assertEquals(transpose_character_before_cursor(0, 'a'),
-                transpose_character_before_cursor(0, 'a'))
+                (0, 'a'))
         self.assertEquals(transpose_character_before_cursor(0, 'as'),
-                transpose_character_before_cursor(0, 'as'))
+                (0, 'as'))
+    
+    def test_transpose_end_of_line(self):
+        self.assertEquals(transpose_character_before_cursor(1, 'a'),
+                (1, 'a'))
+        self.assertEquals(transpose_character_before_cursor(2, 'as'),
+                (2, 'sa'))
 
     def test_transpose_word_before_cursor(self):
         pass


### PR DESCRIPTION
Transpose (Ctrl+t) correctly mimics emacs's transpose behavior.