### PR TITLE
Show single underscore attributes before double underscore ones #528

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -256,7 +256,6 @@ class AttrCompletion(BaseCompletionType):
         if not r.word.split('.')[-1].startswith('_'):
             matches = set(match for match in matches
                           if not match.split('.')[-1].startswith('_'))
-        # MAYBE HERE 2 ??
         return matches
 
     def locate(self, current_offset, line):
@@ -312,8 +311,6 @@ class AttrCompletion(BaseCompletionType):
         for word in words:
             if self.method_match(word, n, attr) and word != "__builtins__":
                 matches.append("%s.%s" % (expr, word))
-#        print 'matches', matches
-        # ORGANIZE THE THINGS HERE MAYBE 1??
         return matches
 
     if py3:

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -559,10 +559,10 @@ def sort_by_underscore(matches):
     if len(matches) == 0 or len(matches) == 1:
         return matches
     one_underscore = None
+    dot = matches[i].rfind('.') + 1
     for i in xrange(1, len(matches)+1):
         i = -i
-        dot_i = matches[i].rfind('.') + 1
-        if matches[i][dot_i] == '_' and matches[i][dot_i+1] != '_':
+        if matches[i][dot] == '_' and matches[i][dot+1] != '_':
             one_underscore = i
         else:
             break

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -558,17 +558,10 @@ def sort_by_underscore(matches):
     matches = sorted(matches)
     if len(matches) == 0 or len(matches) == 1:
         return matches
-    one_underscore = None
-    dot = matches[i].rfind('.') + 1
-    for i in xrange(1, len(matches)+1):
-        i = -i
-        if matches[i][dot] == '_' and matches[i][dot+1] != '_':
-            one_underscore = i
-        else:
-            break
-    if one_underscore != None:
-        return matches[one_underscore:] + matches[:one_underscore]
-    return matches
+    dot = matches[0].rfind('.') + 1
+    single = [m for m in matches if not m[dot:].startswith('__')]
+    double = [m for m in matches if m[dot:].startswith('__')]
+    return single + double
 
 def get_default_completer(mode=SIMPLE):
     return (

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -552,7 +552,8 @@ def get_completer(completers, cursor_offset, line, **kwargs):
     return [], None
 
 def sort_by_underscore(matches):
-    """Sort single underscore attributes before double underscore ones.
+    """Returns a sorted list with single underscore attributes before double 
+    underscore ones.
     """
     matches = sorted(matches)
     if len(matches) == 0 or len(matches) == 1:
@@ -565,7 +566,7 @@ def sort_by_underscore(matches):
             one_underscore = i
         else:
             break
-    if one_underscore_i != None:
+    if one_underscore != None:
         return matches[one_underscore:] + matches[:one_underscore]
     return matches
 

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -256,6 +256,7 @@ class AttrCompletion(BaseCompletionType):
         if not r.word.split('.')[-1].startswith('_'):
             matches = set(match for match in matches
                           if not match.split('.')[-1].startswith('_'))
+        # MAYBE HERE 2 ??
         return matches
 
     def locate(self, current_offset, line):
@@ -311,6 +312,8 @@ class AttrCompletion(BaseCompletionType):
         for word in words:
             if self.method_match(word, n, attr) and word != "__builtins__":
                 matches.append("%s.%s" % (expr, word))
+#        print 'matches', matches
+        # ORGANIZE THE THINGS HERE MAYBE 1??
         return matches
 
     if py3:
@@ -543,13 +546,31 @@ def get_completer(completers, cursor_offset, line, **kwargs):
         complete_magic_methods is a bool of whether we ought to complete
             double underscore methods like __len__ in method signatures
     """
-
     for completer in completers:
         matches = completer.matches(cursor_offset, line, **kwargs)
         if matches is not None:
-            return sorted(matches), (completer if matches else None)
+            if len(matches) > 0:
+                matches = sort_by_underscore(matches)
+            return matches, (completer if matches else None)
     return [], None
 
+def sort_by_underscore(matches):
+    """Sort single underscore attributes before double underscore ones.
+    """
+    matches = sorted(matches)
+    if len(matches) == 0 or len(matches) == 1:
+        return matches
+    one_underscore = None
+    for i in xrange(1, len(matches)+1):
+        i = -i
+        dot_i = matches[i].rfind('.') + 1
+        if matches[i][dot_i] == '_' and matches[i][dot_i+1] != '_':
+            one_underscore = i
+        else:
+            break
+    if one_underscore_i != None:
+        return matches[one_underscore:] + matches[:one_underscore]
+    return matches
 
 def get_default_completer(mode=SIMPLE):
     return (

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -88,12 +88,9 @@ class TestGetCompleter(unittest.TestCase):
     def test_first_completer_returns_None(self):
         a = completer(None)
         b = completer(['a'])
+        print '\n\n\n', b.matches, '\n\n\n'
         self.assertEqual(autocomplete.get_completer([a, b], 0, ''), (['a'], b))
 
-    def test_completer_shows_single_underscore_before_double(self):
-        # TODO: do this!
-        a = completer([])
-        
 
 
 class TestCumulativeCompleter(unittest.TestCase):
@@ -268,7 +265,6 @@ class TestAttrCompletion(unittest.TestCase):
                       self.com.matches(3, 'a._', locals_=locals_))
 
 
-
 class TestMagicMethodCompletion(unittest.TestCase):
 
     def test_magic_methods_complete_after_double_underscores(self):
@@ -371,3 +367,6 @@ class TestParameterNameCompletion(unittest.TestCase):
                             set(['banana=']))
         self.assertSetEqual(com.matches(3, "car", argspec=argspec),
                             set(['carrot=']))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -88,9 +88,7 @@ class TestGetCompleter(unittest.TestCase):
     def test_first_completer_returns_None(self):
         a = completer(None)
         b = completer(['a'])
-        print '\n\n\n', b.matches, '\n\n\n'
         self.assertEqual(autocomplete.get_completer([a, b], 0, ''), (['a'], b))
-
 
 
 class TestCumulativeCompleter(unittest.TestCase):
@@ -367,6 +365,3 @@ class TestParameterNameCompletion(unittest.TestCase):
                             set(['banana=']))
         self.assertSetEqual(com.matches(3, "car", argspec=argspec),
                             set(['carrot=']))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -90,6 +90,11 @@ class TestGetCompleter(unittest.TestCase):
         b = completer(['a'])
         self.assertEqual(autocomplete.get_completer([a, b], 0, ''), (['a'], b))
 
+    def test_completer_shows_single_underscore_before_double(self):
+        # TODO: do this!
+        a = completer([])
+        
+
 
 class TestCumulativeCompleter(unittest.TestCase):
 
@@ -261,6 +266,7 @@ class TestAttrCompletion(unittest.TestCase):
         locals_ = {'a': OldStyleWithBrokenGetAttr()}
         self.assertIn(u'a.__module__',
                       self.com.matches(3, 'a._', locals_=locals_))
+
 
 
 class TestMagicMethodCompletion(unittest.TestCase):


### PR DESCRIPTION
Autocomplete shows single underscore attributes before double underscore ones, as per Tom's suggestion.