### PR TITLE
Filter out two underscore attributes in auto completion

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -253,7 +253,12 @@ class AttrCompletion(BaseCompletionType):
         # TODO add open paren for methods via _callable_prefix (or decide not
         # to) unless the first character is a _ filter out all attributes
         # starting with a _
-        if not r.word.split('.')[-1].startswith('_'):
+        if r.word.split('.')[-1].startswith('__'):
+            pass
+        elif r.word.split('.')[-1].startswith('_'):
+            matches = set(match for match in matches
+                          if not match.split('.')[-1].startswith('__'))
+        else:
             matches = set(match for match in matches
                           if not match.split('.')[-1].startswith('_'))
         return matches

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -245,12 +245,12 @@ class TestAttrCompletion(unittest.TestCase):
                                              locals_={'a': OldStyleFoo()}),
                             set(['a.method', 'a.a', 'a.b']))
         self.assertIn(u'a.__dict__',
-                      self.com.matches(3, 'a._', locals_={'a': OldStyleFoo()}))
+                      self.com.matches(3, 'a.__', locals_={'a': OldStyleFoo()}))
 
     @skip_old_style
     def test_att_matches_found_on_old_style_class_object(self):
         self.assertIn(u'A.__dict__',
-                      self.com.matches(3, 'A._', locals_={'A': OldStyleFoo}))
+                      self.com.matches(3, 'A.__', locals_={'A': OldStyleFoo}))
 
     @skip_old_style
     def test_issue536(self):
@@ -260,7 +260,7 @@ class TestAttrCompletion(unittest.TestCase):
 
         locals_ = {'a': OldStyleWithBrokenGetAttr()}
         self.assertIn(u'a.__module__',
-                      self.com.matches(3, 'a._', locals_=locals_))
+                      self.com.matches(3, 'a.__', locals_=locals_))
 
 
 class TestMagicMethodCompletion(unittest.TestCase):

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -245,12 +245,12 @@ class TestAttrCompletion(unittest.TestCase):
                                              locals_={'a': OldStyleFoo()}),
                             set(['a.method', 'a.a', 'a.b']))
         self.assertIn(u'a.__dict__',
-                      self.com.matches(3, 'a.__', locals_={'a': OldStyleFoo()}))
+                      self.com.matches(4, 'a.__', locals_={'a': OldStyleFoo()}))
 
     @skip_old_style
     def test_att_matches_found_on_old_style_class_object(self):
         self.assertIn(u'A.__dict__',
-                      self.com.matches(3, 'A.__', locals_={'A': OldStyleFoo}))
+                      self.com.matches(4, 'A.__', locals_={'A': OldStyleFoo}))
 
     @skip_old_style
     def test_issue536(self):
@@ -260,7 +260,7 @@ class TestAttrCompletion(unittest.TestCase):
 
         locals_ = {'a': OldStyleWithBrokenGetAttr()}
         self.assertIn(u'a.__module__',
-                      self.com.matches(3, 'a.__', locals_=locals_))
+                      self.com.matches(4, 'a.__', locals_=locals_))
 
 
 class TestMagicMethodCompletion(unittest.TestCase):


### PR DESCRIPTION
This change will require you to write two underscores in order to get autocompletion of attributes starting with two underscores, as requested in #528.

I'm not too sure about the changes to the tests, and if there should be some tests for this filtering as well. I just tried to make the change as minimal as possible while making the tests pass.