### PR TITLE
Fix small python 3 compatibility issue using windows

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -281,7 +281,7 @@ def make_colors(config):
     }
 
     if platform.system() == 'Windows':
-        c = dict(c.items() +
+        c = dict(c.items() |
             [
             ('K', 8),
             ('R', 9),


### PR DESCRIPTION
Something I bumped into getting bpython on windows. Python 3 doesn't allow addition of dict_items and list in make_colors if OS is windows, but union works!