### PR TITLE
Show __new__ docstrings. Fixes #572

### DIFF
--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -231,7 +231,9 @@ def getfuncprops(func, f):
     try:
         is_bound_method = ((inspect.ismethod(f) and f.__self__ is not None)
                            or (func_name == '__init__' and not
-                               func.endswith('.__init__')))
+                               func.endswith('.__init__'))
+                           or (func_name == '__new__' and not
+                               func.endswith('.__new__')))
     except:
         # if f is a method from a xmlrpclib.Server instance, func_name ==
         # '__init__' throws xmlrpclib.Fault (see #202)

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -527,11 +527,21 @@ class Repl(object):
             return False
 
         if inspect.isclass(f):
-            try:
-                if f.__init__ is not object.__init__:
-                    f = f.__init__
-            except AttributeError:
-                return None
+            class_f = None
+
+            if (hasattr(f, '__init__') and
+                f.__init__ is not object.__init__):
+                    class_f = f.__init__
+            if ((not class_f or
+                not inspection.getfuncprops(func, class_f)) and
+                hasattr(f, '__new__') and
+                f.__new__ is not object.__new__ and
+                f.__new__.__class__ is not object.__new__.__class__):  # py3
+                    class_f = f.__new__
+
+            if class_f:
+                f = class_f
+
         self.current_func = f
         self.funcprops = inspection.getfuncprops(func, f)
         if self.funcprops:

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -138,6 +138,14 @@ class TestArgspec(unittest.TestCase):
         self.repl.push("    def spam(self, a, b, c):\n", False)
         self.repl.push("        pass\n", False)
         self.repl.push("\n", False)
+        self.repl.push("class SpammitySpam(object):\n", False)
+        self.repl.push("    def __init__(self, a, b, c):\n", False)
+        self.repl.push("        pass\n", False)
+        self.repl.push("\n", False)
+        self.repl.push("class WonderfulSpam(object):\n", False)
+        self.repl.push("    def __new__(self, a, b, c):\n", False)
+        self.repl.push("        pass\n", False)
+        self.repl.push("\n", False)
         self.repl.push("o = Spam()\n", False)
         self.repl.push("\n", False)
 
@@ -206,6 +214,13 @@ class TestArgspec(unittest.TestCase):
     def test_nonexistent_name(self):
         self.set_input_line("spamspamspam(")
         self.assertFalse(self.repl.get_args())
+
+    def test_issue572(self):
+        self.set_input_line("SpammitySpam(")
+        self.assertTrue(self.repl.get_args())
+
+        self.set_input_line("WonderfulSpam(")
+        self.assertTrue(self.repl.get_args())
 
 
 class TestGetSource(unittest.TestCase):


### PR DESCRIPTION
```
>>> import blessed
>>> blessed.sequences.Sequence(
┌────────────────────────────────────────────────────────────┐
│ blessed.sequences.Sequence: (cls, sequence_text, term)     │
│ Sequence                                                   │
│ SequenceTextWrapper                                        │
│ Class constructor.                                         │
│                                                            │
│ :arg sequence_text: A string that may contain sequences.   │
│ :arg blessed.Terminal term: :class:`~.Terminal` instance.  │
└────────────────────────────────────────────────────────────┘
```
