### PR TITLE
fix parameter name completion

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -160,17 +160,17 @@ class CumulativeCompleter(BaseCompletionType):
         return self._completers[0].format(word)
 
     def matches(self, cursor_offset, line, **kwargs):
+        return_value = None
         all_matches = set()
         for completer in self._completers:
-            # these have to be explicitely listed to deal with the different
-            # signatures of various matches() methods of completers
             matches = completer.matches(cursor_offset=cursor_offset,
                                         line=line,
                                         **kwargs)
             if matches is not None:
                 all_matches.update(matches)
+                return_value = all_matches
 
-        return all_matches
+        return return_value
 
 
 class ImportCompletion(BaseCompletionType):
@@ -634,11 +634,11 @@ def get_default_completer(mode=SIMPLE):
         FilenameCompletion(mode=mode),
         MagicMethodCompletion(mode=mode),
         MultilineJediCompletion(mode=mode),
-        GlobalCompletion(mode=mode),
-        ArrayItemMembersCompletion(mode=mode),
-        CumulativeCompleter((AttrCompletion(mode=mode),
+        CumulativeCompleter((GlobalCompletion(mode=mode),
                              ParameterNameCompletion(mode=mode)),
-                            mode=mode)
+                            mode=mode),
+        ArrayItemMembersCompletion(mode=mode),
+        AttrCompletion(mode=mode),
     )
 
 

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -107,10 +107,10 @@ class TestCumulativeCompleter(unittest.TestCase):
         cumulative = autocomplete.CumulativeCompleter([a])
         self.assertEqual(cumulative.matches(3, 'abc'), set())
 
-    def test_one_none_completer_returns_empty(self):
+    def test_one_none_completer_returns_none(self):
         a = self.completer(None)
         cumulative = autocomplete.CumulativeCompleter([a])
-        self.assertEqual(cumulative.matches(3, 'abc'), set())
+        self.assertEqual(cumulative.matches(3, 'abc'), None)
 
     def test_two_completers_get_both(self):
         a = self.completer(['a'])

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -383,7 +383,7 @@ class TestRepl(unittest.TestCase):
         self.assertTrue(hasattr(self.repl.matches_iter, 'matches'))
         self.assertEqual(self.repl.matches_iter.matches, ['Foo.bar'])
 
-    # 3. Edge Cases
+    # 3. Edge cases
     def test_updating_namespace_complete(self):
         self.repl = FakeRepl({'autocomplete_mode': autocomplete.SIMPLE})
         self.set_input_line("foo")
@@ -399,6 +399,19 @@ class TestRepl(unittest.TestCase):
         self.assertTrue(self.repl.complete())
         self.assertTrue(hasattr(self.repl.matches_iter, 'matches'))
         self.assertNotIn('__file__', self.repl.matches_iter.matches)
+
+    # 4. Parameter names
+    def test_paremeter_name_completion(self):
+        self.repl = FakeRepl({'autocomplete_mode': autocomplete.SIMPLE})
+        self.set_input_line("foo(ab")
+
+        code = "def foo(abc=1, abd=2, xyz=3):\n\tpass\n"
+        for line in code.split("\n"):
+            self.repl.push(line)
+
+        self.assertTrue(self.repl.complete())
+        self.assertTrue(hasattr(self.repl.matches_iter, 'matches'))
+        self.assertEqual(self.repl.matches_iter.matches, ['abc=', 'abd=', 'abs('])
 
 
 class TestCliRepl(unittest.TestCase):


### PR DESCRIPTION
I found parameter name completion wasn't working. I don't know if it's ever worked. Now this happens:

    bpython version 0.15.dev177 on top of Python 2.7.10 /Users/tomb/.virtualenvs/bpython/bin/python2.7
    >>> def foo(abc=1, abd=2, xyz=3):
    ...     "function with keyword parameters"
    ...
    >>> foo(ab
    ┌──────────────────────────────────────────────────┐
    │ foo: (abc=1, abd=2, xyz=3)                       │
    │ abc= abd= abs(                                   │
    │ function with keyword parameters                 │
    └──────────────────────────────────────────────────┘
