### PR TITLE
fix run order-dependant test failure

### DIFF
--- a/bpython/test/test_curtsies_repl.py
+++ b/bpython/test/test_curtsies_repl.py
@@ -20,6 +20,12 @@ from bpython._py3compat import py3
 from bpython.test import (FixLanguageTestCase as TestCase, MagicIterMock, mock,
                           builtin_target, unittest)
 
+if py3:
+    from importlib import invalidate_caches
+else:
+    def invalidate_caches():
+        """Does not exist before Python 3.3"""
+
 
 def setup_config(conf):
     config_struct = config.Struct()
@@ -291,6 +297,7 @@ class TestCurtsiesReevaluateWithImport(TestCase):
         self.open = partial(io.open, mode='wt', encoding='utf-8')
         self.dont_write_bytecode = sys.dont_write_bytecode
         sys.dont_write_bytecode = True
+        invalidate_caches()
 
     def tearDown(self):
         sys.dont_write_bytecode = self.dont_write_bytecode

--- a/bpython/test/test_curtsies_repl.py
+++ b/bpython/test/test_curtsies_repl.py
@@ -297,6 +297,19 @@ class TestCurtsiesReevaluateWithImport(TestCase):
         self.open = partial(io.open, mode='wt', encoding='utf-8')
         self.dont_write_bytecode = sys.dont_write_bytecode
         sys.dont_write_bytecode = True
+
+        # Because these tests create Python source files at runtime,
+        # it's possible for the importlib.machinery.FileFinder for
+        # a directory to have an outdated cache in the following situation:
+        # * a module in that directory is imported,
+        # * then a new module is created in that directory,
+        # * then that new module is imported.
+        #
+        # invalidate_cache() is used to prevent this.
+        #
+        # see https://docs.python.org/3/library/importlib.html
+        # sections #importlib.machinery.FileFinder and
+        # #importlib.invalidate_caches
         invalidate_caches()
 
     def tearDown(self):


### PR DESCRIPTION
Possibly we should have a test that explicitly tests for this behavior, but with our current tests I got failures only when tests were run in a specific order.