### PR TITLE
Paste detection in bpython instead of Curtsies, fixes #575

### DIFF
--- a/bpython/curtsies.py
+++ b/bpython/curtsies.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import code
+import collections
 import io
 import logging
 import sys
@@ -91,10 +92,44 @@ def main(args=None, locals_=None, banner=None, welcome_message=None):
     return extract_exit_value(exit_value)
 
 
+def _combined_events(event_provider, paste_threshold):
+    """Combines consecutive keypress events into paste events."""
+    timeout = (yield 'nonsense_event')  # so send can be used
+    queue = collections.deque()
+    while True:
+        e = event_provider.send(timeout)
+        if isinstance(e, curtsies.events.Event):
+            timeout = (yield e)
+            continue
+        elif e is None:
+            continue
+        else:
+            queue.append(e)
+        e = event_provider.send(0)
+        while not (e is None or isinstance(e, curtsies.events.Event)):
+            queue.append(e)
+            e = event_provider.send(0)
+        if len(queue) >= paste_threshold:
+            paste = curtsies.events.PasteEvent()
+            paste.events.extend(queue)
+            queue.clear()
+            yield paste
+        else:
+            while len(queue):
+                yield queue.popleft()
+
+
+def combined_events(event_provider, paste_threshold=10):
+    g = _combined_events(event_provider, paste_threshold)
+    next(g)
+    return g
+
+
 def mainloop(config, locals_, banner, interp=None, paste=None,
              interactive=True):
-    with curtsies.input.Input(keynames='curtsies', sigint_event=True) as \
-            input_generator:
+    with curtsies.input.Input(keynames='curtsies',
+                              sigint_event=True,
+                              paste_threshold=None) as input_generator:
         with curtsies.window.CursorAwareWindow(
                 sys.stdout,
                 sys.stdin,
@@ -180,12 +215,13 @@ def mainloop(config, locals_, banner, interp=None, paste=None,
 
                 # do a display before waiting for first event
                 process_event(None)
+                inputs = combined_events(input_generator)
                 for unused in find_iterator:
-                    e = input_generator.send(0)
+                    e = inputs.send(0)
                     if e is not None:
                         process_event(e)
 
-                for e in input_generator:
+                for e in inputs:
                     process_event(e)
 
 

--- a/bpython/curtsies.py
+++ b/bpython/curtsies.py
@@ -120,7 +120,7 @@ def _combined_events(event_provider, paste_threshold):
                 timeout = yield queue.popleft()
 
 
-def combined_events(event_provider, paste_threshold=10):
+def combined_events(event_provider, paste_threshold=3):
     g = _combined_events(event_provider, paste_threshold)
     next(g)
     return g

--- a/bpython/curtsies.py
+++ b/bpython/curtsies.py
@@ -94,14 +94,15 @@ def main(args=None, locals_=None, banner=None, welcome_message=None):
 
 def _combined_events(event_provider, paste_threshold):
     """Combines consecutive keypress events into paste events."""
-    timeout = (yield 'nonsense_event')  # so send can be used
+    timeout = yield 'nonsense_event'  # so send can be used immediately
     queue = collections.deque()
     while True:
         e = event_provider.send(timeout)
         if isinstance(e, curtsies.events.Event):
-            timeout = (yield e)
+            timeout = yield e
             continue
         elif e is None:
+            timeout = yield None
             continue
         else:
             queue.append(e)
@@ -113,10 +114,10 @@ def _combined_events(event_provider, paste_threshold):
             paste = curtsies.events.PasteEvent()
             paste.events.extend(queue)
             queue.clear()
-            yield paste
+            timeout = yield paste
         else:
             while len(queue):
-                yield queue.popleft()
+                timeout = yield queue.popleft()
 
 
 def combined_events(event_provider, paste_threshold=10):

--- a/bpython/test/test_curtsies.py
+++ b/bpython/test/test_curtsies.py
@@ -49,15 +49,15 @@ class EventGenerator(object):
 
 class TestCurtsiesPasteDetection(TestCase):
     def test_paste_threshold(self):
-        inputs = combined_events(EventGenerator(list('abc')))
-        cb = combined_events(inputs, paste_threshold=3)
+        eg = EventGenerator(list('abc'))
+        cb = combined_events(eg, paste_threshold=3)
         e = next(cb)
         self.assertIsInstance(e, curtsies.events.PasteEvent)
         self.assertEqual(e.events, list('abc'))
         self.assertEqual(next(cb), None)
 
-        inputs = combined_events(EventGenerator(list('abc')))
-        cb = combined_events(inputs, paste_threshold=4)
+        eg = EventGenerator(list('abc'))
+        cb = combined_events(eg, paste_threshold=4)
         self.assertEqual(next(cb), 'a')
         self.assertEqual(next(cb), 'b')
         self.assertEqual(next(cb), 'c')
@@ -67,8 +67,7 @@ class TestCurtsiesPasteDetection(TestCase):
         eg = EventGenerator('a', zip('bcdefg', [1, 2, 3, 3, 3, 4]))
         eg.schedule_event(curtsies.events.SigIntEvent(), 5)
         eg.schedule_event('h', 6)
-        inputs = combined_events(eg)
-        cb = combined_events(inputs, paste_threshold=3)
+        cb = combined_events(eg, paste_threshold=3)
         self.assertEqual(next(cb), 'a')
         self.assertEqual(cb.send(0), None)
         self.assertEqual(next(cb), 'b')

--- a/bpython/test/test_curtsies.py
+++ b/bpython/test/test_curtsies.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+from bpython.curtsies import combined_events
+from bpython.test import (FixLanguageTestCase as TestCase, unittest)
+
+import curtsies.events
+
+
+ScheduledEvent = namedtuple('ScheduledEvent', ['when', 'event'])
+
+
+class EventGenerator(object):
+    def __init__(self, initial_events=(), scheduled_events=()):
+        self._events = []
+        self._current_tick = 0
+        for e in initial_events:
+            self.schedule_event(e, 0)
+        for e, w in scheduled_events:
+            self.schedule_event(e, w)
+
+    def schedule_event(self, event, when):
+        self._events.append(ScheduledEvent(when, event))
+        self._events.sort()
+
+    def send(self, timeout=None):
+        if timeout not in [None, 0]:
+            raise ValueError('timeout value %r not supported' % timeout)
+        if not self._events:
+            return None
+        if self._events[0].when <= self._current_tick:
+            return self._events.pop(0).event
+
+        if timeout == 0:
+            return None
+        elif timeout is None:
+            e = self._events.pop(0)
+            self._current_tick = e.when
+            return e.event
+        else:
+            raise ValueError('timeout value %r not supported' % timeout)
+
+    def tick(self, dt=1):
+        self._current_tick += dt
+
+
+class TestCurtsiesPasteDetection(TestCase):
+    def test_paste_threshold(self):
+        inputs = combined_events(EventGenerator(list('abc')))
+        cb = combined_events(inputs, paste_threshold=3)
+        e = next(cb)
+        self.assertIsInstance(e, curtsies.events.PasteEvent)
+        self.assertEqual(e.events, list('abc'))
+        self.assertEqual(next(cb), None)
+
+        inputs = combined_events(EventGenerator(list('abc')))
+        cb = combined_events(inputs, paste_threshold=4)
+        self.assertEqual(next(cb), 'a')
+        self.assertEqual(next(cb), 'b')
+        self.assertEqual(next(cb), 'c')
+        self.assertEqual(next(cb), None)
+
+    def test_set_timeout(self):
+        eg = EventGenerator('a', zip('bcd', [1,2,3]))
+        inputs = combined_events(eg)
+        cb = combined_events(inputs, paste_threshold=5)
+        self.assertEqual(next(cb), 'a')
+        self.assertEqual(cb.send(0), None)
+        self.assertEqual(next(cb), 'b')
+        self.assertEqual(cb.send(0), None)
+        eg.tick()
+        self.assertEqual(cb.send(0), 'c')
+        self.assertEqual(cb.send(0), None)
+        eg.tick()
+        self.assertEqual(cb.send(0), 'd')
+        self.assertEqual(cb.send(0), None)
+
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This switches from using curtsies-created paste events to creating paste events in bpython whenever 10  or more keypress events are queued up.

I think long term this is a good move because it's one less Curtsies-specific piece of input functionality, and I'd like to remove this feature from Curtsies and use Blessed for input code eventually because I trust @jquast to get it right more than I do myself. It's also better because now it helps the UI catch up any time it gets behind on events, e.g. from a fast typist on a slow machine, whereas before the bytes had to be read in the same system call to be considered a paste event. The paste threshold of 10 should be tuned for this, it should probably be much lower (2 or 3?).

If you don't like the `combined_events` coroutine I'd be happy to reimplement it as a class, I think that might be clearer but because the `.send` and `next()` interface was all we needed it seemed easy to write that way.