### PR TITLE
WIP Safe Callable attr parens

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -707,8 +707,12 @@ def attr_lookup(obj, expr, attr):
     n = len(attr)
     for word in words:
         if method_match(word, n, attr) and word != "__builtins__":
-            attr_obj = inspection.safe_get_attribute(obj, word)
-            matches.append(_callable_postfix(attr_obj, "%s.%s" % (expr, word)))
+            try:
+                attr_obj = inspection.safe_get_attribute(obj, word)
+            except AttributeError:
+                matches.append("%s.%s" % (expr, word))
+            else:
+                matches.append(_callable_postfix(attr_obj, "%s.%s" % (expr, word)))
     return matches
 
 

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -707,7 +707,7 @@ def attr_lookup(obj, expr, attr):
     n = len(attr)
     for word in words:
         if method_match(word, n, attr) and word != "__builtins__":
-            attr_obj = getattr(obj, word)  # scary!
+            attr_obj = inspection.safe_get_attribute(obj, word)
             matches.append(_callable_postfix(attr_obj, "%s.%s" % (expr, word)))
     return matches
 

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -253,8 +253,10 @@ class AttrCompletion(BaseCompletionType):
         matches = set(''.join([r.word[:-i], m])
                       for m in self.attr_matches(methodtext, locals_))
 
-        # TODO add open paren for methods via _callable_prefix (or decide not
-        # to) unless the first character is a _ filter out all attributes
+        # TODO add open paren for methods via _callable_prefix
+        matches = set(_callable_postfix(eval(m, locals_), m)
+                      for m in matches)
+        # unless the first character is a _ filter out all attributes
         # starting with a _
         if r.word.split('.')[-1].startswith('__'):
             pass

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -292,6 +292,12 @@ def safe_get_attribute(obj, attr):
     Returns AttributeIsEmptySlot if requested attribute does not have a value,
     but is a slot entry.
     """
+    if is_new_style(obj):
+        return safe_get_attribute_new_style(obj, attr)
+    return getattr(obj, attr)
+
+
+def safe_get_attribute_new_style(obj, attr):
     if not is_new_style(obj):
         raise ValueError("%r is not a new-style class or object" % obj)
     to_look_through = (obj.mro()

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -69,7 +69,7 @@ class AttrCleaner(object):
         # original methods. :-(
         # The upshot being that introspecting on an object to display its
         # attributes will avoid unwanted side-effects.
-        if py3 or type_ != types.InstanceType:
+        if is_new_style(self.obj):
             __getattr__ = getattr(type_, '__getattr__', None)
             if __getattr__ is not None:
                 try:
@@ -96,6 +96,14 @@ class AttrCleaner(object):
         if __getattr__ is not None:
             setattr(type_, '__getattr__', __getattr__)
         # /Dark magic
+
+
+if py3:
+    is_new_style = lambda obj: True
+else:
+    def is_new_style(obj):
+        """Returns True if obj is a new-style class or object"""
+        return type(obj) != types.InstanceType and hasattr(obj, '__class__')
 
 
 class _Repr(object):

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -242,7 +242,7 @@ class TestAttrCompletion(unittest.TestCase):
 
     def test_att_matches_found_on_instance(self):
         self.assertSetEqual(self.com.matches(2, 'a.', locals_={'a': Foo()}),
-                            set(['a.method', 'a.a', 'a.b']))
+                            set(['a.method(', 'a.a', 'a.b']))
 
     @skip_old_style
     def test_att_matches_found_on_old_style_instance(self):

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -32,12 +32,6 @@ class TestSafeEval(unittest.TestCase):
         with self.assertRaises(autocomplete.EvaluationError):
             autocomplete.safe_eval('1re', {})
 
-    def test_doesnt_eval_properties(self):
-        self.assertRaises(autocomplete.EvaluationError,
-                          autocomplete.safe_eval, '1re', {})
-        p = Properties()
-        autocomplete.safe_eval('p.asserts_when_called', {'p': p})
-
 
 class TestFormatters(unittest.TestCase):
 

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -32,6 +32,12 @@ class TestSafeEval(unittest.TestCase):
         with self.assertRaises(autocomplete.EvaluationError):
             autocomplete.safe_eval('1re', {})
 
+    def test_doesnt_eval_properties(self):
+        self.assertRaises(autocomplete.EvaluationError,
+                          autocomplete.safe_eval, '1re', {})
+        p = Properties()
+        autocomplete.safe_eval('p.asserts_when_called', {'p': p})
+
 
 class TestFormatters(unittest.TestCase):
 
@@ -233,6 +239,13 @@ class OldStyleFoo:
 
 skip_old_style = unittest.skipIf(py3,
                                  'In Python 3 there are no old style classes')
+
+
+class Properties(Foo):
+
+    @property
+    def asserts_when_called(self):
+        raise AssertionError("getter method called")
 
 
 class TestAttrCompletion(unittest.TestCase):

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -274,6 +274,11 @@ class TestAttrCompletion(unittest.TestCase):
         self.assertIn(u'a.__module__',
                       self.com.matches(4, 'a.__', locals_=locals_))
 
+    def test_descriptor_attributes_not_run(self):
+        com = autocomplete.AttrCompletion()
+        self.assertSetEqual(com.matches(2, 'a.', locals_={'a': Properties()}),
+                            set(['a.asserts_when_called']))
+
 
 class TestArrayItemCompletion(unittest.TestCase):
     @classmethod

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -277,7 +277,8 @@ class TestAttrCompletion(unittest.TestCase):
     def test_descriptor_attributes_not_run(self):
         com = autocomplete.AttrCompletion()
         self.assertSetEqual(com.matches(2, 'a.', locals_={'a': Properties()}),
-                            set(['a.asserts_when_called']))
+                            set(['a.b', 'a.a', 'a.method(',
+                                 'a.asserts_when_called']))
 
 
 class TestArrayItemCompletion(unittest.TestCase):

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -242,6 +242,10 @@ class Properties(Foo):
         raise AssertionError("getter method called")
 
 
+class Slots(object):
+    __slots__ = ['a', 'b']
+
+
 class TestAttrCompletion(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -279,6 +283,11 @@ class TestAttrCompletion(unittest.TestCase):
         self.assertSetEqual(com.matches(2, 'a.', locals_={'a': Properties()}),
                             set(['a.b', 'a.a', 'a.method(',
                                  'a.asserts_when_called']))
+
+    def test_slots_not_crash(self):
+        com = autocomplete.AttrCompletion()
+        self.assertSetEqual(com.matches(2, 'A.', locals_={'A': Slots}),
+                            set(['A.b', 'A.a', 'A.mro']))
 
 
 class TestArrayItemCompletion(unittest.TestCase):

--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -20,29 +20,35 @@ foo_non_ascii = u'''def foo():
 '''
 
 
+class OldCallable:
+    def __call__(self):
+        pass
+
+
+class Callable(object):
+    def __call__(self):
+        pass
+
+
+class OldNoncallable:
+    pass
+
+
+class Noncallable(object):
+    pass
+
+
+def spam():
+    pass
+
+
+class CallableMethod(object):
+    def method(self):
+        pass
+
+
 class TestInspection(unittest.TestCase):
     def test_is_callable(self):
-        class OldCallable:
-            def __call__(self):
-                pass
-
-        class Callable(object):
-            def __call__(self):
-                pass
-
-        class OldNoncallable:
-            pass
-
-        class Noncallable(object):
-            pass
-
-        def spam():
-            pass
-
-        class CallableMethod(object):
-            def method(self):
-                pass
-
         self.assertTrue(inspection.is_callable(spam))
         self.assertTrue(inspection.is_callable(Callable))
         self.assertTrue(inspection.is_callable(Callable()))
@@ -52,6 +58,14 @@ class TestInspection(unittest.TestCase):
         self.assertFalse(inspection.is_callable(OldNoncallable()))
         self.assertFalse(inspection.is_callable(None))
         self.assertTrue(inspection.is_callable(CallableMethod().method))
+
+    def test_is_new_style(self):
+        self.assertTrue(inspection.is_new_style(spam))
+        self.assertTrue(inspection.is_new_style(Noncallable))
+        self.assertFalse(inspection.is_new_style(OldNoncallable))
+        self.assertTrue(inspection.is_new_style(Noncallable()))
+        self.assertFalse(inspection.is_new_style(OldNoncallable()))
+        self.assertTrue(inspection.is_new_style(None))
 
     def test_parsekeywordpairs(self):
         # See issue #109

--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -146,37 +146,39 @@ class Property(object):
     def prop(self):
         raise AssertionError('Property __get__ executed')
 
+
 class Slots(object):
     __slots__ = ['s1', 's2']
+
 
 class TestSafeGetAttribute(unittest.TestCase):
 
     def test_lookup_on_object(self):
         a = A()
         a.x = 1
-        self.assertEquals(inspection.safe_get_attribute(a, 'x'), 1)
-        self.assertEquals(inspection.safe_get_attribute(a, 'a'), 'a')
+        self.assertEquals(inspection.safe_get_attribute_new_style(a, 'x'), 1)
+        self.assertEquals(inspection.safe_get_attribute_new_style(a, 'a'), 'a')
         b = B()
         b.y = 2
-        self.assertEquals(inspection.safe_get_attribute(b, 'y'), 2)
-        self.assertEquals(inspection.safe_get_attribute(b, 'a'), 'a')
-        self.assertEquals(inspection.safe_get_attribute(b, 'b'), 'b')
+        self.assertEquals(inspection.safe_get_attribute_new_style(b, 'y'), 2)
+        self.assertEquals(inspection.safe_get_attribute_new_style(b, 'a'), 'a')
+        self.assertEquals(inspection.safe_get_attribute_new_style(b, 'b'), 'b')
 
     def test_avoid_running_properties(self):
         p = Property()
-        self.assertEquals(inspection.safe_get_attribute(p, 'prop'),
+        self.assertEquals(inspection.safe_get_attribute_new_style(p, 'prop'),
                           Property.prop)
 
     def test_raises_on_old_style_class(self):
         class Old: pass
         with self.assertRaises(ValueError):
-            inspection.safe_get_attribute(Old, 'asdf')
+            inspection.safe_get_attribute_new_style(Old, 'asdf')
 
     def test_lookup_with_slots(self):
         s = Slots()
         s.s1 = 's1'
-        self.assertEquals(inspection.safe_get_attribute(s, 's1'), 's1')
-        self.assertEquals(inspection.safe_get_attribute(s, 's2'),
+        self.assertEquals(inspection.safe_get_attribute_new_style(s, 's1'), 's1')
+        self.assertEquals(inspection.safe_get_attribute_new_style(s, 's2'),
                           inspection.AttributeIsEmptySlot)
 
 

--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -2,6 +2,8 @@
 
 import os
 
+
+from bpython._py3compat import py3
 from bpython import inspection
 from bpython.test import unittest
 from bpython.test.fodder import encoding_ascii
@@ -59,13 +61,24 @@ class TestInspection(unittest.TestCase):
         self.assertFalse(inspection.is_callable(None))
         self.assertTrue(inspection.is_callable(CallableMethod().method))
 
-    def test_is_new_style(self):
+    @unittest.skipIf(py3, 'old-style classes only exist in Python 2')
+    def test_is_new_style_py2(self):
         self.assertTrue(inspection.is_new_style(spam))
         self.assertTrue(inspection.is_new_style(Noncallable))
         self.assertFalse(inspection.is_new_style(OldNoncallable))
         self.assertTrue(inspection.is_new_style(Noncallable()))
         self.assertFalse(inspection.is_new_style(OldNoncallable()))
         self.assertTrue(inspection.is_new_style(None))
+
+    @unittest.skipUnless(py3, 'only in Python 3 are all classes new-style')
+    def test_is_new_style_py3(self):
+        self.assertTrue(inspection.is_new_style(spam))
+        self.assertTrue(inspection.is_new_style(Noncallable))
+        self.assertTrue(inspection.is_new_style(OldNoncallable))
+        self.assertTrue(inspection.is_new_style(Noncallable()))
+        self.assertTrue(inspection.is_new_style(OldNoncallable()))
+        self.assertTrue(inspection.is_new_style(None))
+
 
     def test_parsekeywordpairs(self):
         # See issue #109
@@ -169,6 +182,7 @@ class TestSafeGetAttribute(unittest.TestCase):
         self.assertEquals(inspection.safe_get_attribute_new_style(p, 'prop'),
                           Property.prop)
 
+    @unittest.skipIf(py3, 'Old-style classes not in Python 3')
     def test_raises_on_old_style_class(self):
         class Old: pass
         with self.assertRaises(ValueError):

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -364,7 +364,7 @@ class TestRepl(unittest.TestCase):
 
         self.assertTrue(self.repl.complete())
         self.assertTrue(hasattr(self.repl.matches_iter, 'matches'))
-        self.assertEqual(self.repl.matches_iter.matches, ['Foo.bar'])
+        self.assertEqual(self.repl.matches_iter.matches, ['Foo.bar('])
 
     def test_substring_attribute_complete(self):
         self.repl = FakeRepl({'autocomplete_mode': autocomplete.SUBSTRING})


### PR DESCRIPTION
Adds machinery for safely doing attribute lookup (e.g. avoiding calling user-defined properties), starts completing attributes with parens if the objects to which they refer are callable, and adds attribute completion to simple expression evaluation (if #580 is merged).

One of the goals of this PR is to *safely* show completions in situations like

    >>> import ast
    >>> m = ast.parse('1 + 1')
    >>> m.body[0].value.

This isn't ready and won't be for a while. TODO:
* consolidate existing inspect.AttrCleaner functionality
* rename existing attribute lookup logic to "unsafe" or similar so its use is explicit
* test that all attribute-style completion still works with the added opening paren
* if https://github.com/bpython/bpython/pull/580 has been merged, add safe attribute completion to this
* confirm no functionality is being lost -- don't stop doing unsafe completion for attribute because this would be changing existing behavior (maybe open a new issue for this), e.g.
~~~
bpython version 0.14.2 on top of Python 2.7.10 /usr/local/opt/python/bin/python2.7
>>> class Foo():
...     @property
...     def foo(self):
...         print 1
...         return 2
...
>>> f = Foo()
1
>>> f.foo.
┌────────────────────────────────────────────────────────────────────┐
│ bit_length        conjugate         denominator                    │
│ imag              numerator         real                           │
└────────────────────────────────────────────────────────────────────┘
~~~
