### PR TITLE
fix #591 changing stack trace linenos

### DIFF
--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -29,6 +29,7 @@ import io
 import os
 import pkgutil
 import pydoc
+import re
 import shlex
 import subprocess
 import sys
@@ -133,6 +134,9 @@ class Interpreter(code.InteractiveInterpreter):
                 # Stuff in the right filename and right lineno
                 if not py3:
                     lineno -= 1
+                if re.match(r'<bpython-input-\d+>', filename):
+                    filename = '<input>'
+                    # strip linecache line number
                 value = SyntaxError(msg, (filename, lineno, offset, line))
                 sys.last_value = value
         list = traceback.format_exception_only(type, value)
@@ -149,9 +153,14 @@ class Interpreter(code.InteractiveInterpreter):
             sys.last_traceback = tb
             tblist = traceback.extract_tb(tb)
             del tblist[:1]
-            # Set the right lineno (encoding header adds an extra line)
-            if not py3:
-                for i, (fname, lineno, module, something) in enumerate(tblist):
+
+            for i, (fname, lineno, module, something) in enumerate(tblist):
+                # strip linecache line number
+                if re.match(r'<bpython-input-\d+>', fname):
+                    fname = '<input>'
+                    tblist[i] = (fname, lineno, module, something)
+                # Set the right lineno (encoding header adds an extra line)
+                if not py3:
                     if fname == '<input>':
                         tblist[i] = (fname, lineno - 1, module, something)
 

--- a/bpython/test/test_interpreter.py
+++ b/bpython/test/test_interpreter.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import linecache
 import sys
 
 from curtsies.fmtfuncs import bold, green, magenta, cyan, red, plain
@@ -12,12 +11,6 @@ from bpython._py3compat import py3
 from bpython.test import mock, unittest
 
 pypy = 'PyPy' in sys.version
-
-
-def _last_console_filename():
-    """Returns the last 'filename' used for console input
-    (as will be displayed in a traceback)."""
-    return '<bpython-input-%s>' % (len(linecache.cache.bpython_history) - 1)
 
 
 class TestInterpreter(unittest.TestCase):
@@ -33,13 +26,13 @@ class TestInterpreter(unittest.TestCase):
 
         if pypy:
             expected = (
-                '  File ' + green('"%s"' % _last_console_filename()) +
+                '  File ' + green('"<input>"') +
                 ', line ' + bold(magenta('1')) + '\n    1.1.1.1\n      ^\n' +
                 bold(red('SyntaxError')) + ': ' + cyan('invalid syntax') +
                 '\n')
         else:
             expected = (
-                '  File ' + green('"%s"' % _last_console_filename()) +
+                '  File ' + green('"<input>"') +
                 ', line ' + bold(magenta('1')) + '\n    1.1.1.1\n        ^\n' +
                 bold(red('SyntaxError')) + ': ' + cyan('invalid syntax') +
                 '\n')
@@ -62,7 +55,7 @@ class TestInterpreter(unittest.TestCase):
         def g():
             return f()
 
-        i.runsource('g()', encode=False)
+        i.runsource('g()')
 
         if pypy:
             global_not_found = "global name 'g' is not defined"
@@ -71,7 +64,7 @@ class TestInterpreter(unittest.TestCase):
 
         expected = (
             'Traceback (most recent call last):\n  File ' +
-            green('"%s"' % _last_console_filename()) + ', line ' +
+            green('"<input>"') + ', line ' +
             bold(magenta('1')) + ', in ' + cyan('<module>') + '\n    g()\n' +
             bold(red('NameError')) + ': ' + cyan(global_not_found) + '\n')
 


### PR DESCRIPTION
Mimicking the default Python interactive interpreter, change stack traces so they no longer list the line number.