### PR TITLE
Simple eval attr access

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,8 @@ New features:
 * #538: Multi-line banners are allowed.
 * #229: inspect.getsource works on interactively defined functions.
   Thanks to Michael Mulley.
-* Attribute completion on items in lists and tuples
+* Attribute completion works on literals and some expressions containing
+  builtin objects.
 * Ctrl-e can be used to autocomplete current fish-style suggestion.
   Thanks to Amjith Ramanujam
 

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -69,7 +69,7 @@ class AttrCleaner(object):
         # original methods. :-(
         # The upshot being that introspecting on an object to display its
         # attributes will avoid unwanted side-effects.
-        if py3 or type_ != types.InstanceType:
+        if is_new_style(self.obj):
             __getattr__ = getattr(type_, '__getattr__', None)
             if __getattr__ is not None:
                 try:
@@ -96,6 +96,15 @@ class AttrCleaner(object):
         if __getattr__ is not None:
             setattr(type_, '__getattr__', __getattr__)
         # /Dark magic
+
+
+if py3:
+    def is_new_style(obj):
+        return True
+else:
+    def is_new_style(obj):
+        """Returns True if obj is a new-style class or object"""
+        return type(obj) != types.InstanceType
 
 
 class _Repr(object):

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -104,7 +104,7 @@ if py3:
 else:
     def is_new_style(obj):
         """Returns True if obj is a new-style class or object"""
-        return type(obj) != types.InstanceType
+        return type(obj) not in [types.InstanceType, types.ClassType]
 
 
 class _Repr(object):

--- a/bpython/line.py
+++ b/bpython/line.py
@@ -10,8 +10,11 @@ from collections import namedtuple
 
 from bpython.lazyre import LazyReCompile
 
-current_word_re = LazyReCompile(r'[\w_][\w0-9._]*[(]?')
 LinePart = namedtuple('LinePart', ['start', 'stop', 'word'])
+
+current_word_re = LazyReCompile(
+        r'(?<![)\]\w_.])'
+        r'([\w_][\w0-9._]*[(]?)')
 
 
 def current_word(cursor_offset, line):
@@ -22,10 +25,10 @@ def current_word(cursor_offset, line):
     end = pos
     word = None
     for m in matches:
-        if m.start() < pos and m.end() >= pos:
-            start = m.start()
-            end = m.end()
-            word = m.group()
+        if m.start(1) < pos and m.end(1) >= pos:
+            start = m.start(1)
+            end = m.end(1)
+            word = m.group(1)
     if word is None:
         return None
     return LinePart(start, end, word)

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -479,12 +479,11 @@ class Repl(object):
 
     @classmethod
     def _funcname_and_argnum(cls, line):
+        """Parse out the current function name and arg from a line of code."""
         # each list in stack:
         # [full_expr, function_expr, arg_number, opening]
-        # empty string in num_commas means we've encountered a kwarg
-        # so we're done counting
-
-        # new plan: do a full parse, then combine things
+        # arg_number may be a string if we've encountered a keyword
+        # argument so we're done counting
         stack = [['', '', 0, '']]
         try:
             for (token, value) in PythonLexer().get_tokens(line):

--- a/bpython/simpleeval.py
+++ b/bpython/simpleeval.py
@@ -34,6 +34,7 @@ from six.moves import builtins
 
 from bpython import line as line_properties
 from bpython._py3compat import py3
+from bpython.inspection import is_new_style
 
 _string_type_nodes = (ast.Str, ast.Bytes) if py3 else (ast.Str,)
 _numeric_types = (int, float, complex) + (() if py3 else (long,))
@@ -72,7 +73,9 @@ def safe_eval(expr, namespace):
 def simple_eval(node_or_string, namespace=None):
     """
     Safely evaluate an expression node or a string containing a Python
-    expression.  The string or node provided may only consist of:
+    expression without triggering any user code.
+
+    The string or node provided may only consist of:
     * the following Python literal structures: strings, numbers, tuples,
         lists, and dicts
     * variable names causing lookups in the passed in namespace or builtins
@@ -143,6 +146,12 @@ def simple_eval(node_or_string, namespace=None):
             obj = _convert(node.value)
             index = _convert(node.slice.value)
             return safe_getitem(obj, index)
+
+        # this is a deviation from literal_eval: we allow attribute access
+        if isinstance(node, ast.Attribute):
+            obj = _convert(node.value)
+            attr = node.attr
+            return safe_get_attribute(obj, attr)
 
         raise ValueError('malformed string')
     return _convert(node_or_string)
@@ -225,3 +234,46 @@ def evaluate_current_attribute(cursor_offset, line, namespace=None):
     except AttributeError:
         raise EvaluationError(
                 "can't lookup attribute %s on %r" % (attr.word, obj))
+
+
+def safe_get_attribute(obj, attr):
+    """Gets attributes without triggering descriptors on new-style clases"""
+    if is_new_style(obj):
+        result = safe_get_attribute_new_style(obj, attr)
+        if isinstance(result, member_descriptor):
+            # will either be the same slot descriptor or the value
+            return getattr(obj, attr)
+        return result
+    return getattr(obj, attr)
+
+
+class _ClassWithSlots(object):
+    __slots__ = ['a']
+member_descriptor = type(_ClassWithSlots.a)
+
+
+def safe_get_attribute_new_style(obj, attr):
+    """Returns approximately the attribute returned by getattr(obj, attr)
+
+    The object returned ought to be callable if getattr(obj, attr) was.
+    Fake callable objects may be returned instead, in order to avoid executing
+    arbitrary code in descriptors.
+
+    If the object is an instance of a class that uses __slots__, will return
+    the member_descriptor object instead of the value.
+    """
+    if not is_new_style(obj):
+        raise ValueError("%r is not a new-style class or object" % obj)
+    to_look_through = (obj.mro()
+                       if hasattr(obj, 'mro')
+                       else [obj] + type(obj).mro())
+
+    found_in_slots = hasattr(obj, '__slots__') and attr in obj.__slots__
+    for cls in to_look_through:
+        if hasattr(cls, '__dict__') and attr in cls.__dict__:
+            return cls.__dict__[attr]
+
+    if found_in_slots:
+        return AttributeIsEmptySlot
+
+    raise AttributeError()

--- a/bpython/simpleeval.py
+++ b/bpython/simpleeval.py
@@ -29,9 +29,11 @@ In order to provide fancy completion, some code can be executed safely.
 """
 
 import ast
-from six import string_types
 import inspect
+from six import string_types
 from six.moves import builtins
+import sys
+import types
 
 from bpython import line as line_properties
 from bpython._py3compat import py3
@@ -45,6 +47,14 @@ if hasattr(ast, 'NameConstant'):
     _name_type_nodes = (ast.Name, ast.NameConstant)
 else:
     _name_type_nodes = (ast.Name,)
+
+
+# inspect.isclass is broken in Python 2.6
+if sys.version_info[:2] == (2, 6):
+    def isclass(obj):
+        return isinstance(obj, (type, types.ClassType))
+else:
+    isclass = inspect.isclass
 
 
 class EvaluationError(Exception):
@@ -267,7 +277,7 @@ def safe_get_attribute_new_style(obj, attr):
     if not is_new_style(obj):
         raise ValueError("%r is not a new-style class or object" % obj)
     to_look_through = (obj.__mro__
-                       if inspect.isclass(obj)
+                       if isclass(obj)
                        else (obj,) + type(obj).__mro__)
 
     for cls in to_look_through:

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -235,6 +235,17 @@ skip_old_style = unittest.skipIf(py3,
                                  'In Python 3 there are no old style classes')
 
 
+class Properties(Foo):
+
+    @property
+    def asserts_when_called(self):
+        raise AssertionError("getter method called")
+
+
+class Slots(object):
+    __slots__ = ['a', 'b']
+
+
 class TestAttrCompletion(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -267,6 +278,17 @@ class TestAttrCompletion(unittest.TestCase):
         locals_ = {'a': OldStyleWithBrokenGetAttr()}
         self.assertIn(u'a.__module__',
                       self.com.matches(4, 'a.__', locals_=locals_))
+
+    def test_descriptor_attributes_not_run(self):
+        com = autocomplete.AttrCompletion()
+        self.assertSetEqual(com.matches(2, 'a.', locals_={'a': Properties()}),
+                            set(['a.b', 'a.a', 'a.method',
+                                 'a.asserts_when_called']))
+
+    def test_slots_not_crash(self):
+        com = autocomplete.AttrCompletion()
+        self.assertSetEqual(com.matches(2, 'A.', locals_={'A': Slots}),
+                            set(['A.b', 'A.a', 'A.mro']))
 
 
 class TestExpressionAttributeCompletion(unittest.TestCase):

--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -2,6 +2,7 @@
 
 import os
 
+from bpython._py3compat import py3
 from bpython import inspection
 from bpython.test import unittest
 from bpython.test.fodder import encoding_ascii
@@ -20,29 +21,35 @@ foo_non_ascii = u'''def foo():
 '''
 
 
+class OldCallable:
+    def __call__(self):
+        pass
+
+
+class Callable(object):
+    def __call__(self):
+        pass
+
+
+class OldNoncallable:
+    pass
+
+
+class Noncallable(object):
+    pass
+
+
+def spam():
+    pass
+
+
+class CallableMethod(object):
+    def method(self):
+        pass
+
+
 class TestInspection(unittest.TestCase):
     def test_is_callable(self):
-        class OldCallable:
-            def __call__(self):
-                pass
-
-        class Callable(object):
-            def __call__(self):
-                pass
-
-        class OldNoncallable:
-            pass
-
-        class Noncallable(object):
-            pass
-
-        def spam():
-            pass
-
-        class CallableMethod(object):
-            def method(self):
-                pass
-
         self.assertTrue(inspection.is_callable(spam))
         self.assertTrue(inspection.is_callable(Callable))
         self.assertTrue(inspection.is_callable(Callable()))
@@ -52,6 +59,25 @@ class TestInspection(unittest.TestCase):
         self.assertFalse(inspection.is_callable(OldNoncallable()))
         self.assertFalse(inspection.is_callable(None))
         self.assertTrue(inspection.is_callable(CallableMethod().method))
+
+    @unittest.skipIf(py3, 'old-style classes only exist in Python 2')
+    def test_is_new_style_py2(self):
+        self.assertTrue(inspection.is_new_style(spam))
+        self.assertTrue(inspection.is_new_style(Noncallable))
+        self.assertFalse(inspection.is_new_style(OldNoncallable))
+        self.assertTrue(inspection.is_new_style(Noncallable()))
+        self.assertFalse(inspection.is_new_style(OldNoncallable()))
+        self.assertTrue(inspection.is_new_style(None))
+
+    @unittest.skipUnless(py3, 'only in Python 3 are all classes new-style')
+    def test_is_new_style_py3(self):
+        self.assertTrue(inspection.is_new_style(spam))
+        self.assertTrue(inspection.is_new_style(Noncallable))
+        self.assertTrue(inspection.is_new_style(OldNoncallable))
+        self.assertTrue(inspection.is_new_style(Noncallable()))
+        self.assertTrue(inspection.is_new_style(OldNoncallable()))
+        self.assertTrue(inspection.is_new_style(None))
+
 
     def test_parsekeywordpairs(self):
         # See issue #109

--- a/bpython/test/test_line_properties.py
+++ b/bpython/test/test_line_properties.py
@@ -5,7 +5,7 @@ from bpython.line import current_word, current_dict_key, current_dict, \
     current_string, current_object, current_object_attribute, \
     current_from_import_from, current_from_import_import, current_import, \
     current_method_definition_name, current_single_word, \
-    current_expression_attribute
+    current_expression_attribute, current_dotted_attribute
 
 
 def cursor(s):
@@ -128,6 +128,15 @@ class TestCurrentWord(LineTestCase):
         self.assertAccess('stuff[stuff] + {123: 456} + <Object.attr1.attr2|>')
         self.assertAccess('stuff[<asd|fg>]')
         self.assertAccess('stuff[asdf[<asd|fg>]')
+
+    def test_non_dots(self):
+        self.assertAccess('].asdf|')
+        self.assertAccess(').asdf|')
+        self.assertAccess('foo[0].asdf|')
+        self.assertAccess('foo().asdf|')
+        self.assertAccess('foo().|')
+        self.assertAccess('foo().asdf.|')
+        self.assertAccess('foo[0].asdf.|')
 
     def test_open_paren(self):
         self.assertAccess('<foo(|>')
@@ -335,6 +344,17 @@ class TestCurrentExpressionAttribute(LineTestCase):
         self.assertAccess('"hey".asdf d|')
         self.assertAccess('"hey".<|>')
 
+
+class TestCurrentDottedAttribute(LineTestCase):
+    def setUp(self):
+        self.func = current_dotted_attribute
+
+    def test_simple(self):
+        self.assertAccess('<obj.attr>|')
+        self.assertAccess('(<obj.attr>|')
+        self.assertAccess('[<obj.attr>|')
+        self.assertAccess('m.body[0].value|')
+        self.assertAccess('m.body[0].attr.value|')
 
 if __name__ == '__main__':
     unittest.main()

--- a/bpython/test/test_line_properties.py
+++ b/bpython/test/test_line_properties.py
@@ -11,7 +11,7 @@ from bpython.line import current_word, current_dict_key, current_dict, \
 def cursor(s):
     """'ab|c' -> (2, 'abc')"""
     cursor_offset = s.index('|')
-    line = s[:cursor_offset] + s[cursor_offset+1:]
+    line = s[:cursor_offset] + s[cursor_offset + 1:]
     return cursor_offset, line
 
 
@@ -53,11 +53,12 @@ def encode(cursor_offset, line, result):
     if start < cursor_offset:
         encoded_line = encoded_line[:start] + '<' + encoded_line[start:]
     else:
-        encoded_line = encoded_line[:start+1] + '<' + encoded_line[start+1:]
+        encoded_line = (encoded_line[:start + 1] + '<' +
+                        encoded_line[start + 1:])
     if end < cursor_offset:
-        encoded_line = encoded_line[:end+1] + '>' + encoded_line[end+1:]
+        encoded_line = encoded_line[:end + 1] + '>' + encoded_line[end + 1:]
     else:
-        encoded_line = encoded_line[:end+2] + '>' + encoded_line[end+2:]
+        encoded_line = encoded_line[:end + 2] + '>' + encoded_line[end + 2:]
     return encoded_line
 
 

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -238,6 +238,30 @@ class TestArgspec(unittest.TestCase):
         self.assertTrue(self.repl.get_args())
 
 
+class TestArgspecInternal(unittest.TestCase):
+    def test_function_expressions(self):
+        te = self.assertTupleEqual
+        fa = lambda line: repl.Repl._funcname_and_argnum(line)
+        for line, (func, argnum) in [
+            ('spam(', ('spam', 0)),
+            ('spam((), ', ('spam', 1)),
+            ('spam.eggs((), ', ('spam.eggs', 1)),
+            ('spam[abc].eggs((), ', ('spam[abc].eggs', 1)),
+            ('spam[0].eggs((), ', ('spam[0].eggs', 1)),
+            ('spam[a + b]eggs((), ', ('spam[a + b]eggs', 1)),
+            ('spam().eggs((), ', ('spam().eggs', 1)),
+            ('spam(1, 2).eggs((), ', ('spam(1, 2).eggs', 1)),
+            ('spam(1, f(1)).eggs((), ', ('spam(1, f(1)).eggs', 1)),
+            ('[0].eggs((), ', ('[0].eggs', 1)),
+            ('[0][0]((), {}).eggs((), ', ('[0][0]((), {}).eggs', 1)),
+            ('a + spam[0].eggs((), ', ('spam[0].eggs', 1)),
+            ("spam(", ("spam", 0)),
+            ("spam(map([]", ("map", 0)),
+            ("spam((), ", ("spam", 1))
+                ]:
+            te(fa(line), (func, argnum))
+
+
 class TestGetSource(unittest.TestCase):
     def setUp(self):
         self.repl = FakeRepl()

--- a/bpython/test/test_simpleeval.py
+++ b/bpython/test/test_simpleeval.py
@@ -5,8 +5,11 @@ import numbers
 
 from bpython.simpleeval import (simple_eval,
                                 evaluate_current_expression,
-                                EvaluationError)
+                                EvaluationError,
+                                safe_get_attribute,
+                                safe_get_attribute_new_style)
 from bpython.test import unittest
+from bpython._py3compat import py3
 
 
 class TestSimpleEval(unittest.TestCase):
@@ -86,6 +89,12 @@ class TestSimpleEval(unittest.TestCase):
         with self.assertRaises(EvaluationError):
             simple_eval('a')
 
+    def test_attribute_access(self):
+        class Foo(object):
+            abc = 1
+
+        self.assertEqual(simple_eval('foo.abc', {'foo': Foo()}), 1)
+
 
 class TestEvaluateCurrentExpression(unittest.TestCase):
 
@@ -122,6 +131,92 @@ class TestEvaluateCurrentExpression(unittest.TestCase):
     def test_with_namespace(self):
         self.assertEvaled('a[1].a|bc', 'd', {'a': 'adsf'})
         self.assertCannotEval('a[1].a|bc', {})
+
+
+class A(object):
+    a = 'a'
+
+
+class B(A):
+    b = 'b'
+
+
+class Property(object):
+    @property
+    def prop(self):
+        raise AssertionError('Property __get__ executed')
+
+
+class Slots(object):
+    __slots__ = ['s1', 's2', 's3']
+
+    if not py3:
+        @property
+        def s3(self):
+            raise AssertionError('Property __get__ executed')
+
+
+class SlotsSubclass(Slots):
+    @property
+    def s4(self):
+        raise AssertionError('Property __get__ executed')
+
+
+member_descriptor = type(Slots.s1)
+
+
+class TestSafeGetAttribute(unittest.TestCase):
+
+    def test_lookup_on_object(self):
+        a = A()
+        a.x = 1
+        self.assertEquals(safe_get_attribute_new_style(a, 'x'), 1)
+        self.assertEquals(safe_get_attribute_new_style(a, 'a'), 'a')
+        b = B()
+        b.y = 2
+        self.assertEquals(safe_get_attribute_new_style(b, 'y'), 2)
+        self.assertEquals(safe_get_attribute_new_style(b, 'a'), 'a')
+        self.assertEquals(safe_get_attribute_new_style(b, 'b'), 'b')
+
+    def test_avoid_running_properties(self):
+        p = Property()
+        self.assertEquals(safe_get_attribute_new_style(p, 'prop'),
+                          Property.prop)
+
+    @unittest.skipIf(py3, 'Old-style classes not in Python 3')
+    def test_raises_on_old_style_class(self):
+        class Old:
+            pass
+        with self.assertRaises(ValueError):
+            safe_get_attribute_new_style(Old, 'asdf')
+
+    def test_lookup_with_slots(self):
+        s = Slots()
+        s.s1 = 's1'
+        self.assertEquals(safe_get_attribute(s, 's1'), 's1')
+        self.assertIsInstance(safe_get_attribute_new_style(s, 's1'),
+                              member_descriptor)
+        with self.assertRaises(AttributeError):
+            safe_get_attribute(s, 's2')
+        self.assertIsInstance(safe_get_attribute_new_style(s, 's2'),
+                              member_descriptor)
+
+    def test_lookup_on_slots_classes(self):
+        sga = safe_get_attribute
+        s = SlotsSubclass()
+        self.assertIsInstance(sga(Slots, 's1'), member_descriptor)
+        self.assertIsInstance(sga(SlotsSubclass, 's1'), member_descriptor)
+        self.assertIsInstance(sga(SlotsSubclass, 's4'), property)
+        self.assertIsInstance(sga(s, 's4'), property)
+
+    @unittest.skipIf(py3, "Py 3 doesn't allow slots and prop in same class")
+    def test_lookup_with_property_and_slots(self):
+        sga = safe_get_attribute
+        s = SlotsSubclass()
+        self.assertIsInstance(sga(Slots, 's3'), property)
+        self.assertEquals(safe_get_attribute(s, 's3'),
+                          Slots.__dict__['s3'])
+        self.assertIsInstance(sga(SlotsSubclass, 's3'), property)
 
 if __name__ == '__main__':
     unittest.main()

--- a/bpython/test/test_simpleeval.py
+++ b/bpython/test/test_simpleeval.py
@@ -162,6 +162,24 @@ class SlotsSubclass(Slots):
         raise AssertionError('Property __get__ executed')
 
 
+class OverridenGetattr(object):
+    def __getattr__(self, attr):
+        raise AssertionError('custom __getattr__ executed')
+    a = 1
+
+
+class OverridenGetattribute(object):
+    def __getattribute__(self, attr):
+        raise AssertionError('custom __getattrribute__ executed')
+    a = 1
+
+
+class OverridenMRO(object):
+    def __mro__(self):
+        raise AssertionError('custom mro executed')
+    a = 1
+
+
 member_descriptor = type(Slots.s1)
 
 
@@ -217,6 +235,18 @@ class TestSafeGetAttribute(unittest.TestCase):
         self.assertEquals(safe_get_attribute(s, 's3'),
                           Slots.__dict__['s3'])
         self.assertIsInstance(sga(SlotsSubclass, 's3'), property)
+
+    def test_lookup_on_overriden_methods(self):
+        sga = safe_get_attribute
+        self.assertEqual(sga(OverridenGetattr(), 'a'), 1)
+        self.assertEqual(sga(OverridenGetattribute(), 'a'), 1)
+        self.assertEqual(sga(OverridenMRO(), 'a'), 1)
+        with self.assertRaises(AttributeError):
+            sga(OverridenGetattr(), 'b')
+        with self.assertRaises(AttributeError):
+            sga(OverridenGetattribute(), 'b')
+        with self.assertRaises(AttributeError):
+            sga(OverridenMRO(), 'b')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Safely do attribute access to provide completion on simple expressions:
```
>>> import ast
>>> m = ast.parse('1 + 1')
>>> m.body[0].value.
┌───────────────────────────────────────────────────
│ col_offset left       lineno     op         right
└───────────────────────────────────────────────────
```