### PR TITLE
require unicode for pager

### DIFF
--- a/bpython/curtsiesfrontend/_internal.py
+++ b/bpython/curtsiesfrontend/_internal.py
@@ -23,6 +23,8 @@
 import pydoc
 
 import bpython._internal
+from bpython._py3compat import py3
+from bpython.repl import getpreferredencoding
 
 
 class NopPydocPager(object):
@@ -46,6 +48,8 @@ class _Helper(bpython._internal._Helper):
         super(_Helper, self).__init__()
 
     def pager(self, output):
+        if not py3 and isinstance(output, str):
+            output = output.decode(getpreferredencoding())
         self._repl.pager(output)
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
This should probably be looking at the the source for an encoding message, but I'm worried that by the time pydoc outputs this it's too late to find it.