### PR TITLE
Emulate what "sys.stdout" does for "encoding"

### DIFF
--- a/bpython/curtsiesfrontend/coderunner.py
+++ b/bpython/curtsiesfrontend/coderunner.py
@@ -218,3 +218,8 @@ class FakeOutput(object):
 
     def isatty(self):
         return True
+        
+    @property
+    def encoding(self):
+        return 'UTF-8'
+ 


### PR DESCRIPTION
This is similar to #293, which was fixed in a similar way. That case was for "sys.stdin".

Programs use this to check whether they need to encode a string before printing to standard out.