### PR TITLE
Fix TypeError when using F2 without some source

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -974,7 +974,7 @@ class CLIRepl(repl.Repl):
             try:
                 source = self.get_source_of_current_name()
             except repl.SourceNotFound as e:
-                self.statusbar.message(_(e))
+                self.statusbar.message(str(e))
             else:
                 if config.highlight_show_source:
                     source = format(PythonLexer().get_tokens(source),

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1682,7 +1682,7 @@ class BaseRepl(BpythonRepl):
         try:
             source = self.get_source_of_current_name()
         except SourceNotFound as e:
-            self.status_bar.message('%s' % (e, ))
+            self.status_bar.message(str(e))
         else:
             if self.config.highlight_show_source:
                 source = format(PythonLexer().get_tokens(source),


### PR DESCRIPTION
      File "/usr/lib/python3.5/site-packages/bpython/cli.py", line 977, in p_key
        self.statusbar.message(_(e))
      File "/usr/lib/python3.5/site-packages/bpython/cli.py", line 1605, in message
        self.settext(s)
      File "/usr/lib/python3.5/site-packages/bpython/cli.py", line 1655, in settext
        if len(s) >= self.w:
    TypeError: object of type 'SourceNotFound' has no len()

I have used the same code as with `bpython/curtsiesfrontend/repl.py`.