### PR TITLE
Added fileno support to FakeOutput

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -389,8 +389,9 @@ class BaseRepl(BpythonRepl):
         self.orig_tcattrs = orig_tcattrs
 
         self.coderunner = CodeRunner(self.interp, self.request_refresh)
-        self.stdout = FakeOutput(self.coderunner, self.send_to_stdout)
-        self.stderr = FakeOutput(self.coderunner, self.send_to_stderr)
+        # Added explicit fileno definitions to reflect to backend device
+        self.stdout = FakeOutput(self.coderunner, self.send_to_stdout, fileno=1)
+        self.stderr = FakeOutput(self.coderunner, self.send_to_stderr, fileno=2)
         self.stdin = FakeStdin(self.coderunner, self, self.edit_keys)
 
         # next paint should clear screen


### PR DESCRIPTION
Some applications that use curses require that the object in `sys.stdout` be a file with the a method called `fileno`. In order to facilitate this, a `fileno` method was added to the FakeOutput object. An extra named parameter was added to the constructor as well to facilitate choosing the result of the `fileno` method. The default value is `1` (or standard output). 

The two allocations of FakeOutput (for stderr and stdout) were also changed to specify the file number to be returned by `fileno`.

These additions do not effect any existing code, but allow users to import libraries such as pwntools while using bpython.