### PR TITLE
don't encode the file in "bpython file.py"

### DIFF
--- a/bpython/args.py
+++ b/bpython/args.py
@@ -119,5 +119,5 @@ def exec_code(interpreter, args):
     sys.modules['__console__'] = mod
     interpreter.locals = mod.__dict__
     interpreter.locals['__file__'] = args[0]
-    interpreter.runsource(source, args[0], 'exec')
+    interpreter.runsource(source, args[0], 'exec', False)
     sys.argv = old_argv


### PR DESCRIPTION
I'd like to do this to solve https://github.com/bpython/bpython/issues/608 but I'm never positive about encoding issues.

In Python 2 if we're reading a file from the command line, it's totally reasonable for us not to add our own encoding line, right? If it needs to be encoded, then there needed to be an encoding line there and if there is then we're munging it.