### PR TITLE
completion box size changes based on terminal size

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1251,7 +1251,9 @@ class BaseRepl(BpythonRepl):
         self.current_stdouterr_line = ''
         self.stdin.current_line = '\n'
 
-    def paint(self, about_to_exit=False, user_quit=False):
+    def paint(self, about_to_exit=False, user_quit=False,
+              try_preserve_history_height=40,
+              min_infobox_height=4):
         """Returns an array of min_height or more rows and width columns, plus
         cursor position
 
@@ -1259,6 +1261,10 @@ class BaseRepl(BpythonRepl):
         a diff and only write to the screen in portions that have changed, but
         the idea is that we don't need to worry about that here, instead every
         frame is completely redrawn because less state is cool!
+
+        try_preserve_history_height is the the number of rows of content that
+        must be visible before the suggestion box scrolls the terminal in order
+        to display more than min_infobox_height rows of suggestions, docs etc.
         """
         # The hairiest function in the curtsies
         if about_to_exit:
@@ -1412,15 +1418,12 @@ class BaseRepl(BpythonRepl):
             else:
                 # Logic for determining size of completion box
                 # smallest allowed over-full completion box
-                minimum_possible_height = 4
-                # smallest amount of history that must be visible
-                try_preserve_history_height = 40
                 preferred_height = max(
                         # always make infobox at least this height
-                        minimum_possible_height,
+                        min_infobox_height,
 
-                        # there's so much space that we can preserve
-                        # this much history and still expand the infobox
+                        # use this value if there's so much space that we can
+                        # preserve this try_preserve_history_height rows history
                         min_height - try_preserve_history_height)
 
                 info_max_rows = min(max(visible_space_below,

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1260,7 +1260,7 @@ class BaseRepl(BpythonRepl):
         the idea is that we don't need to worry about that here, instead every
         frame is completely redrawn because less state is cool!
         """
-        # The hairiest function in the curtsies - a cleanup would be great.
+        # The hairiest function in the curtsies
         if about_to_exit:
             # exception to not changing state!
             self.clean_up_current_line_for_exit()
@@ -1501,6 +1501,7 @@ class BaseRepl(BpythonRepl):
         if clear_special_mode:
             self.special_mode = None
         self.unhighlight_paren()
+
     current_line = property(_get_current_line, _set_current_line, None,
                             "The current line")
 

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1252,8 +1252,8 @@ class BaseRepl(BpythonRepl):
         self.stdin.current_line = '\n'
 
     def paint(self, about_to_exit=False, user_quit=False,
-              try_preserve_history_height=40,
-              min_infobox_height=4):
+              try_preserve_history_height=30,
+              min_infobox_height=5):
         """Returns an array of min_height or more rows and width columns, plus
         cursor position
 

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1410,10 +1410,21 @@ class BaseRepl(BpythonRepl):
             if self.config.curtsies_list_above:
                 info_max_rows = max(visible_space_above, visible_space_below)
             else:
+                # Logic for determining size of completion box
                 # smallest allowed over-full completion box
-                minimum_possible_height = 20
+                minimum_possible_height = 4
+                # smallest amount of history that must be visible
+                try_preserve_history_height = 40
+                preferred_height = max(
+                        # always make infobox at least this height
+                        minimum_possible_height,
+
+                        # there's so much space that we can preserve
+                        # this much history and still expand the infobox
+                        min_height - try_preserve_history_height)
+
                 info_max_rows = min(max(visible_space_below,
-                                        minimum_possible_height),
+                                        preferred_height),
                                     min_height - current_line_height - 1)
             infobox = paint.paint_infobox(
                     info_max_rows,

--- a/bpython/test/test_curtsies_painting.py
+++ b/bpython/test/test_curtsies_painting.py
@@ -696,7 +696,19 @@ class TestCurtsiesInfoboxPaint(HigherLevelCurtsiesPaintingTest):
                   '| k                |',
                   '| l                |',
                   '+------------------+']
-        self.assert_paint_ignoring_formatting(screen, (0, 8))
+        # behavior before issue #466
+        self.assert_paint_ignoring_formatting(
+                screen, try_preserve_history_height=0)
+        self.assert_paint_ignoring_formatting(
+                screen, min_infobox_height=100)
+        # behavior after issue #466
+        screen = ['>>> abc.',
+                  '+------------------+',
+                  '| aaaaaaaaaaaaaaaa |',
+                  '| b                |',
+                  '| c                |',
+                  '+------------------+']
+        self.assert_paint_ignoring_formatting(screen)
 
     def test_at_bottom_of_screen(self):
         self.repl.get_top_usable_line = lambda: 17  # two lines from bottom
@@ -720,4 +732,16 @@ class TestCurtsiesInfoboxPaint(HigherLevelCurtsiesPaintingTest):
                   '| k                |',
                   '| l                |',
                   '+------------------+']
-        self.assert_paint_ignoring_formatting(screen, (0, 8))
+        # behavior before issue #466
+        self.assert_paint_ignoring_formatting(
+                screen, try_preserve_history_height=0)
+        self.assert_paint_ignoring_formatting(
+                screen, min_infobox_height=100)
+        # behavior after issue #466
+        screen = ['>>> abc.',
+                  '+------------------+',
+                  '| aaaaaaaaaaaaaaaa |',
+                  '| b                |',
+                  '| c                |',
+                  '+------------------+']
+        self.assert_paint_ignoring_formatting(screen)


### PR DESCRIPTION
Fix #466 

Try to preserve n lines of history (`try_preserve_history_height`) unless that space is needed to make the completion box m lines (`min_infobox_height`) long (provided there is content to fill it). If there's space in the terminal below the cursor to fill and infobox content to fill ti with, go ahead and fill it.

TODO:
  [x] - test desired behavior in each case
  [x] - docstring describing this layout technique
