### PR TITLE
Fix fd encodings

### DIFF
--- a/bpython/curtsiesfrontend/coderunner.py
+++ b/bpython/curtsiesfrontend/coderunner.py
@@ -205,7 +205,7 @@ class CodeRunner(object):
 
 
 class FakeOutput(object):
-    def __init__(self, coderunner, on_write, fileno=1):
+    def __init__(self, coderunner, on_write, real_fileobj):
         """Fakes sys.stdout or sys.stderr
 
         on_write should always take unicode
@@ -215,7 +215,7 @@ class FakeOutput(object):
         """
         self.coderunner = coderunner
         self.on_write = on_write
-        self.real_fileno = fileno
+        self._real_fileobj = real_fileobj
 
     def write(self, s, *args, **kwargs):
         if not py3 and isinstance(s, str):
@@ -227,7 +227,7 @@ class FakeOutput(object):
     # have a method called fileno. One example is pwntools. This
     # is not a widespread issue, but is annoying.
     def fileno(self):
-        return self.real_fileno
+        return self._real_fileobj.fileno()
 
     def writelines(self, l):
         for s in l:
@@ -238,3 +238,7 @@ class FakeOutput(object):
 
     def isatty(self):
         return True
+
+    @property
+    def encoding(self):
+        return self._real_fileobj.encoding

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -220,7 +220,7 @@ class FakeStdin(object):
 
     @property
     def encoding(self):
-        return "UTF8"
+        return sys.__stdin__.encoding
 
     # TODO write a read() method?
 

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -421,12 +421,12 @@ class BaseRepl(BpythonRepl):
         self.stdout = FakeOutput(
             self.coderunner,
             self.send_to_stdouterr,
-            fileno=sys.__stdout__.fileno(),
+            real_fileobj=sys.__stdout__,
         )
         self.stderr = FakeOutput(
             self.coderunner,
             self.send_to_stdouterr,
-            fileno=sys.__stderr__.fileno(),
+            real_fileobj=sys.__stderr__,
         )
         self.stdin = FakeStdin(self.coderunner, self, self.edit_keys)
 

--- a/bpython/test/test_curtsies_coderunner.py
+++ b/bpython/test/test_curtsies_coderunner.py
@@ -52,4 +52,4 @@ class TestFakeOutput(unittest.TestCase):
 
     def test_bytes(self):
         out = FakeOutput(mock.Mock(), self.assert_unicode, None)
-        out.write('native string type')
+        out.write("native string type")

--- a/bpython/test/test_curtsies_coderunner.py
+++ b/bpython/test/test_curtsies_coderunner.py
@@ -20,8 +20,8 @@ class TestCodeRunner(unittest.TestCase):
             request_refresh=lambda: self.orig_stdout.flush()
             or self.orig_stderr.flush()
         )
-        stdout = FakeOutput(c, lambda *args, **kwargs: None)
-        stderr = FakeOutput(c, lambda *args, **kwargs: None)
+        stdout = FakeOutput(c, lambda *args, **kwargs: None, None)
+        stderr = FakeOutput(c, lambda *args, **kwargs: None, None)
         sys.stdout = stdout
         sys.stdout = stderr
         c.load_code("1 + 1")
@@ -38,8 +38,8 @@ class TestCodeRunner(unittest.TestCase):
         def ctrlc():
             raise KeyboardInterrupt()
 
-        stdout = FakeOutput(c, lambda x: ctrlc())
-        stderr = FakeOutput(c, lambda *args, **kwargs: None)
+        stdout = FakeOutput(c, lambda x: ctrlc(), None)
+        stderr = FakeOutput(c, lambda *args, **kwargs: None, None)
         sys.stdout = stdout
         sys.stderr = stderr
         c.load_code("1 + 1")
@@ -51,5 +51,5 @@ class TestFakeOutput(unittest.TestCase):
         self.assertIsInstance(s, type(u""))
 
     def test_bytes(self):
-        out = FakeOutput(mock.Mock(), self.assert_unicode)
-        out.write("native string type")
+        out = FakeOutput(mock.Mock(), self.assert_unicode, None)
+        out.write('native string type')


### PR DESCRIPTION
I propose we provide `fileno()` methods and `.encoding` properties on fake file objects that replace sys.stdin/stdout/stderr. Applications may use them in ways that work or in ways that don't, but we should just provide them and see what happens.

Pro: users can use more libraries with bpython

Con: code may break in less expected ways that the straightforward attribute errors they break on now, e.g. the display may break when a program writes directly to sys.stdout.fileno() because that won't be caught by bpython
