### PR TITLE
bpdb: fix TypeError with pdbpp's `__init__`

### DIFF
--- a/bpdb/debugger.py
+++ b/bpdb/debugger.py
@@ -29,8 +29,8 @@ import bpython
 class BPdb(pdb.Pdb):
     """ PDB with BPython support. """
 
-    def __init__(self):
-        pdb.Pdb.__init__(self)
+    def __init__(self, *args, **kwargs):
+        pdb.Pdb.__init__(self, *args, **kwargs)
         self.rcLines = []
         self.prompt = '(BPdb) '
         self.intro = 'Use "B" to enter bpython, Ctrl-d to exit it.'


### PR DESCRIPTION
When using bpdb together with pdb++ [1], using `debug …` will cause a
TypeError, because pdbpp passes in a `Config` kwarg [2].

    …/venv/lib/python3.5/site-packages/pdb.py:647: in do_debug
        return orig_do_debug(self, arg)
    /usr/lib64/python3.5/pdb.py:1090: in do_debug
        p = Pdb(self.completekey, self.stdin, self.stdout)
    …/venv/lib/python3.5/site-packages/pdb.py:636: in new_pdb_with_config
        return self.__class__(*args, **kwds)
    E   TypeError: __init__() got an unexpected keyword argument 'Config'

This patch fixes bpdb to accept and pass on any args/kwargs.

For reference, this is the stacktrace when pdb++ gets instantiated:

  File "…/venv/lib/python3.5/site-packages/pytestbpdb/ptbpdb.py", line 50, in set_trace
    pdb.BPdb().set_trace(frame)
  File "…/venv/lib/python3.5/site-packages/bpdb/debugger.py", line 33, in __init__
    pdb.Pdb.__init__(self)
  File "…/venv/lib/python3.5/site-packages/pdb.py", line 198, in __init__
    print(traceback.print_stack())

1: https://pypi.python.org/pypi/pdbpp/
2: https://bitbucket.org/antocuni/pdb/src/cf937bbd910a8f7fe2b84af7cf5ee9dc96c2fe25/pdb.py?fileviewer=file-view-default#pdb.py-633