### PR TITLE
Fix paste helper

### DIFF
--- a/bpython/paste.py
+++ b/bpython/paste.py
@@ -110,4 +110,3 @@ class PasteHelper(object):
                                     'program\'s output as an URL.'))
 
         return paste_url, None
-    

--- a/bpython/paste.py
+++ b/bpython/paste.py
@@ -109,4 +109,5 @@ class PasteHelper(object):
                 raise PasteFailed(_('Failed to recognize the helper '
                                     'program\'s output as an URL.'))
 
-        return paste_url,
+        return paste_url, None
+    


### PR DESCRIPTION
Currently bpython will crash calling an external helper, this is because it will try to unpack a tuple of one into `paste_url, removal_url` This simply returns `None` as the removal_url. 