### PR TITLE
Get next command with ctrl+o(issue 631)

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -676,7 +676,7 @@ class BaseRepl(BpythonRepl):
         elif e in ("<Ctrl-d>",):
             self.on_control_d()
         elif e in ("<Ctrl-o>",):
-            self.on_control_o()
+            self.operate_and_get_next()
         elif e in ("<Esc+.>",):
             self.get_last_word()
         elif e in key_dispatch[self.config.reverse_incremental_search_key]:
@@ -846,19 +846,24 @@ class BaseRepl(BpythonRepl):
             self.current_line = (self.current_line[:self.cursor_offset] +
                                  self.current_line[(self.cursor_offset + 1):])
 
-    def on_control_o(self):
-        next_idx = -self.rl_history.index + 1
-        next = self.rl_history.entries[next_idx]
-        self.on_enter()
-        print("Next is : " + next)
-        self._set_current_line(next)
-
     def cut_to_buffer(self):
         self.cut_buffer = self.current_line[self.cursor_offset:]
         self.current_line = self.current_line[:self.cursor_offset]
 
     def yank_from_buffer(self):
         pass
+
+    def operate_and_get_next(self):
+        # If we have not navigated back in history
+        # ctrl+o will have the same effect as enter
+        if self.rl_history.index == 0 or self.rl_history.index == 1:
+            self.on_enter()
+            return
+
+        index = self.rl_history.index
+        self.on_enter()
+        self.rl_history.index = index
+        self._set_current_line(self.rl_history.entries[-index], reset_rl_history=False)
 
     def up_one_line(self):
         self.rl_history.enter(self.current_line)

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -970,7 +970,6 @@ class BaseRepl(BpythonRepl):
         if len(char) > 1 or is_nop(char):
             return
         if self.incr_search_mode:
-            print("Incr search mode")
             self.add_to_incremental_search(char)
         else:
             self._set_current_line((self.current_line[:self.cursor_offset] +

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -788,9 +788,11 @@ class BaseRepl(BpythonRepl):
         else:
             self.cut_buffer = cut
 
-    def on_enter(self, insert_into_history=True):
+    def on_enter(self, insert_into_history=True, reset_rl_history=True):
         # so the cursor isn't touching a paren TODO: necessary?
         self._set_cursor_offset(-1, update_completion=False)
+        if reset_rl_history:
+            self.rl_history.reset()
 
         self.history.append(self.current_line)
         self.push(self.current_line, insert_into_history=insert_into_history)
@@ -856,14 +858,7 @@ class BaseRepl(BpythonRepl):
     def operate_and_get_next(self):
         # If we have not navigated back in history
         # ctrl+o will have the same effect as enter
-        if self.rl_history.index == 0 or self.rl_history.index == 1:
-            self.on_enter()
-            return
-
-        index = self.rl_history.index
-        self.on_enter()
-        self.rl_history.index = index
-        self._set_current_line(self.rl_history.entries[-index], reset_rl_history=False)
+        self.on_enter(reset_rl_history=False)
 
     def up_one_line(self):
         self.rl_history.enter(self.current_line)
@@ -1091,7 +1086,12 @@ class BaseRepl(BpythonRepl):
                     self.current_stdouterr_line, self.width))
                 self.current_stdouterr_line = ''
 
-            self._set_current_line(' ' * indent, update_completion=True)
+            if self.rl_history.index == 0:
+                self._set_current_line(' ' * indent, update_completion=True)
+            else:
+                self._set_current_line(self.rl_history.entries[-self.rl_history.index],
+                                       reset_rl_history = False)
+
             self.cursor_offset = len(self.current_line)
 
     def keyboard_interrupt(self):

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1086,10 +1086,10 @@ class BaseRepl(BpythonRepl):
                     self.current_stdouterr_line, self.width))
                 self.current_stdouterr_line = ''
 
-            if self.rl_history.index == 0:
+            if self.rl_history.get_current_hist_index() == 0:
                 self._set_current_line(' ' * indent, update_completion=True)
             else:
-                self._set_current_line(self.rl_history.entries[-self.rl_history.index],
+                self._set_current_line(self.rl_history.entry,
                                        reset_rl_history = False)
 
             self.cursor_offset = len(self.current_line)

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -967,15 +967,12 @@ class BaseRepl(BpythonRepl):
 
     # Handler Helpers
     def add_normal_character(self, char):
-        print("Char is :" + str(char))
         if len(char) > 1 or is_nop(char):
             return
         if self.incr_search_mode:
             print("Incr search mode")
             self.add_to_incremental_search(char)
         else:
-            print("In here current line: " + self.current_line)
-
             self._set_current_line((self.current_line[:self.cursor_offset] +
                                     char +
                                     self.current_line[self.cursor_offset:]),
@@ -983,8 +980,6 @@ class BaseRepl(BpythonRepl):
                                    reset_rl_history=False,
                                    clear_special_mode=False)
             self.cursor_offset += 1
-
-            print("but here: " + self.current_line)
         if (self.config.cli_trim_prompts and
                 self.current_line.startswith(self.ps1)):
             self.current_line = self.current_line[4:]
@@ -1036,7 +1031,6 @@ class BaseRepl(BpythonRepl):
 
         If the interpreter successfully runs the code, clear the buffer
         """
-
         if self.paste_mode:
             self.saved_indent = 0
         else:
@@ -1202,7 +1196,6 @@ class BaseRepl(BpythonRepl):
             pass
         self.old_fs = fs
         return fs
-
 
     @property
     def lines_for_display(self):

--- a/bpython/history.py
+++ b/bpython/history.py
@@ -138,6 +138,9 @@ class History(object):
                 return idx + (0 if include_current else 1)
         return self.index
 
+    def get_current_hist_index(self):
+        return self.index
+
     def find_partial_match_forward(self, search_term, include_current=False):
         add = 0 if include_current else 1
         end = max(0, self.index - (1 - add))


### PR DESCRIPTION
Hi @thomasballinger ,

As discussed, this is an incomplete PR about issue #631 

I can retrieve the next-to-be-shown-line(stored in variable next). I was expect setting the current line to the new one, to work fine and print it. Am I missing something?

Also, apart from print commands, is there any better way to use a debugger here, given that I am running it with python -m?

Thanks,
P.