### PR TITLE
Fix deprecations warnings

### DIFF
--- a/bpython/curtsiesfrontend/manual_readline.py
+++ b/bpython/curtsiesfrontend/manual_readline.py
@@ -10,10 +10,15 @@ from bpython.lazyre import LazyReCompile
 
 import inspect
 from six import iteritems
+from bpython._py3compat import py3
 
 INDENT = 4
 
 # TODO Allow user config of keybindings for these actions
+if py3:
+    getargspec = lambda func: inspect.getargspec(func)[0]
+else:
+    getargspec = lambda func: inspect.signature(func).parameters
 
 
 class AbstractEdits(object):
@@ -38,7 +43,7 @@ class AbstractEdits(object):
                 del self[key]
             else:
                 raise ValueError('key %r already has a mapping' % (key,))
-        params = inspect.getargspec(func)[0]
+        params = getargspec(func)
         args = dict((k, v) for k, v in iteritems(self.default_kwargs)
                     if k in params)
         r = func(**args)
@@ -64,7 +69,7 @@ class AbstractEdits(object):
 
     def call(self, key, **kwargs):
         func = self[key]
-        params = inspect.getargspec(func)[0]
+        params = getargspec(func)
         args = dict((k, v) for k, v in kwargs.items() if k in params)
         return func(**args)
 

--- a/bpython/curtsiesfrontend/manual_readline.py
+++ b/bpython/curtsiesfrontend/manual_readline.py
@@ -15,7 +15,7 @@ from bpython._py3compat import py3
 INDENT = 4
 
 # TODO Allow user config of keybindings for these actions
-if py3:
+if not py3:
     getargspec = lambda func: inspect.getargspec(func)[0]
 else:
     getargspec = lambda func: inspect.signature(func).parameters


### PR DESCRIPTION
`Getargspec` method of `inspect` module was deprecated in py3.
There is `getfullargspec` method but it was deprecated in several py3 versions.
There is no problem if I launch `bpython` itself. But when I launch `bpython` shell from `django` manage command there are a lot of deprecation warning messages.
So I propose to use `signature` method for py3.