### PR TITLE
Allow bpython/bpdb outside main thread

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -11,6 +11,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import unicodedata
 from six.moves import range
@@ -529,12 +530,10 @@ class BaseRepl(BpythonRepl):
         self.orig_sigwinch_handler = signal.getsignal(signal.SIGWINCH)
         self.orig_sigtstp_handler = signal.getsignal(signal.SIGTSTP)
 
-        try:
+        if isinstance(threading.current_thread(), threading._MainThread):
+            # This turns off resize detection and ctrl-z suspension.
             signal.signal(signal.SIGWINCH, self.sigwinch_handler)
             signal.signal(signal.SIGTSTP, self.sigtstp_handler)
-        except ValueError:
-            pass # Ignore "signal only works in main thread"
-            # This turns off resize detection and ctrl-z suspension.
 
         self.orig_meta_path = sys.meta_path
         if self.watcher:
@@ -548,12 +547,10 @@ class BaseRepl(BpythonRepl):
         sys.stdout = self.orig_stdout
         sys.stderr = self.orig_stderr
 
-        try:
+        if isinstance(threading.current_thread(), threading._MainThread):
+            # This turns off resize detection and ctrl-z suspension.
             signal.signal(signal.SIGWINCH, self.orig_sigwinch_handler)
             signal.signal(signal.SIGTSTP, self.orig_sigtstp_handler)
-        except ValueError:
-            pass # Ignore "signal only works in main thread"
-            # This turns off resize detection and ctrl-z suspension.
 
         sys.meta_path = self.orig_meta_path
 

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -533,7 +533,8 @@ class BaseRepl(BpythonRepl):
             signal.signal(signal.SIGWINCH, self.sigwinch_handler)
             signal.signal(signal.SIGTSTP, self.sigtstp_handler)
         except ValueError:
-          pass # Ignore "signal only works in main thread"
+            pass # Ignore "signal only works in main thread"
+            # This turns off resize detection and ctrl-z suspension.
 
         self.orig_meta_path = sys.meta_path
         if self.watcher:
@@ -551,7 +552,8 @@ class BaseRepl(BpythonRepl):
             signal.signal(signal.SIGWINCH, self.orig_sigwinch_handler)
             signal.signal(signal.SIGTSTP, self.orig_sigtstp_handler)
         except ValueError:
-          pass # Ignore "signal only works in main thread"
+            pass # Ignore "signal only works in main thread"
+            # This turns off resize detection and ctrl-z suspension.
 
         sys.meta_path = self.orig_meta_path
 

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -528,8 +528,12 @@ class BaseRepl(BpythonRepl):
         sys.stdin = self.stdin
         self.orig_sigwinch_handler = signal.getsignal(signal.SIGWINCH)
         self.orig_sigtstp_handler = signal.getsignal(signal.SIGTSTP)
-        signal.signal(signal.SIGWINCH, self.sigwinch_handler)
-        signal.signal(signal.SIGTSTP, self.sigtstp_handler)
+
+        try:
+            signal.signal(signal.SIGWINCH, self.sigwinch_handler)
+            signal.signal(signal.SIGTSTP, self.sigtstp_handler)
+        except ValueError:
+          pass # Ignore "signal only works in main thread"
 
         self.orig_meta_path = sys.meta_path
         if self.watcher:
@@ -542,8 +546,13 @@ class BaseRepl(BpythonRepl):
         sys.stdin = self.orig_stdin
         sys.stdout = self.orig_stdout
         sys.stderr = self.orig_stderr
-        signal.signal(signal.SIGWINCH, self.orig_sigwinch_handler)
-        signal.signal(signal.SIGTSTP, self.orig_sigtstp_handler)
+
+        try:
+            signal.signal(signal.SIGWINCH, self.orig_sigwinch_handler)
+            signal.signal(signal.SIGTSTP, self.orig_sigtstp_handler)
+        except ValueError:
+          pass # Ignore "signal only works in main thread"
+
         sys.meta_path = self.orig_meta_path
 
     def sigwinch_handler(self, signum, frame):


### PR DESCRIPTION
Because [signal.signal][1] is only allowed to be called from the main thread, if you use bpdb in another thread it will crash upon entering the repl.  By ignoring the resulting `ValueError` the show can go on.

This makes bpdb useful in Django's runserver, even with threading and/or live reload on.

A question is what to tell the user when this happens? Just ignore it like here, or log something? What on which level?

Feedback much appreciated.

Closes #555 I think

[1]: https://docs.python.org/3/library/signal.html#signal.signal