### PR TITLE
Use width aware slice

### DIFF
--- a/bpython/curtsiesfrontend/replpainter.py
+++ b/bpython/curtsiesfrontend/replpainter.py
@@ -27,12 +27,13 @@ def display_linize(msg, columns, blank_line=False):
     Warning: if msg is empty, returns an empty list of lines"""
     msg = fmtstr(msg)
     try:
-        display_lines = [msg.width_aware_slice(slice(start, end))
+        display_lines = ([msg.width_aware_slice(slice(start, end))
                           for start, end in zip(
                               range(0, msg.width, columns),
                               range(columns, msg.width + columns, columns))]
+                          if msg else ([''] if blank_line else []))
     except ValueError:
-        display_lines = ([''] if blank_line else [])
+        display_lines = ['']
     return display_lines
 
 

--- a/bpython/curtsiesfrontend/replpainter.py
+++ b/bpython/curtsiesfrontend/replpainter.py
@@ -25,11 +25,14 @@ def display_linize(msg, columns, blank_line=False):
     """Returns lines obtained by splitting msg over multiple lines.
 
     Warning: if msg is empty, returns an empty list of lines"""
-    display_lines = ([msg[start:end]
-                      for start, end in zip(
-                          range(0, len(msg), columns),
-                          range(columns, len(msg) + columns, columns))]
-                     if msg else ([''] if blank_line else []))
+    msg = fmtstr(msg)
+    try:
+        display_lines = [msg.width_aware_slice(slice(start, end))
+                          for start, end in zip(
+                              range(0, msg.width, columns),
+                              range(columns, msg.width + columns, columns))]
+    except ValueError:
+        display_lines = ([''] if blank_line else [])
     return display_lines
 
 


### PR DESCRIPTION
Fixes #670.

May not work with the last curtsies release, tested with the git version.

Although, I'm not sure if converting to FmtStr is the most efficient way of splitting lines, but curtsies.formatstring.width_aware_slice was not working as I've expected.