### PR TITLE
Fix option-backspace behavior

### DIFF
--- a/bpython/curtsiesfrontend/manual_readline.py
+++ b/bpython/curtsiesfrontend/manual_readline.py
@@ -323,7 +323,7 @@ def titlecase_next_word(cursor_offset, line):
     return cursor_offset, line  # TODO Not implemented
 
 
-delete_word_from_cursor_back_re = LazyReCompile(r'\b\w')
+delete_word_from_cursor_back_re = LazyReCompile(r'^|\b\w')
 
 
 @edit_keys.on('<Esc+BACKSPACE>')

--- a/bpython/test/test_manual_readline.py
+++ b/bpython/test/test_manual_readline.py
@@ -240,6 +240,12 @@ class TestManualReadline(unittest.TestCase):
             "|"],
             delete_word_from_cursor_back)
 
+        self.try_stages_kill([
+            " (( asdf |",
+            " (( |",
+            "|"],
+            delete_word_from_cursor_back)
+
 
 class TestEdits(unittest.TestCase):
 


### PR DESCRIPTION
Fixes #655
Just needed a slight tweak to the regex to ensure it always allows deleting to the beginning of the line.