### PR TITLE
Change __name__ to '__main__'

### DIFF
--- a/bpython/args.py
+++ b/bpython/args.py
@@ -117,8 +117,8 @@ def exec_code(interpreter, args):
         source = sourcefile.read()
     old_argv, sys.argv = sys.argv, args
     sys.path.insert(0, os.path.abspath(os.path.dirname(args[0])))
-    mod = imp.new_module('__console__')
-    sys.modules['__console__'] = mod
+    mod = imp.new_module('__main__')
+    sys.modules['__main__'] = mod
     interpreter.locals = mod.__dict__
     interpreter.locals['__file__'] = args[0]
     interpreter.runsource(source, args[0], 'exec')


### PR DESCRIPTION
The behavior of other repls (`python` and `ipython`) is to set `__name__` to `'__main__'`. You can test this by simply printing `__name__` or by running bpython on some file that has a  `__name__ == '__main__'` guard. This was first changed in https://github.com/bpython/bpython/issues/506 but as noted in that issue, the original reason for changing has been lost. Since `__name__ == '__main__'` is so common (it appears 16 times in this codebase alone), it's a significant annoyance to not be able to run files in bpython with that guard. I request you change it back to this more useful behavior.