### PR TITLE
fix encoding issues in urwid and curses

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -330,7 +330,7 @@ class CLIRepl(repl.Repl):
         repl.Repl.__init__(self, interp, config)
         self.interp.writetb = self.writetb
         self.scr = scr
-        self.stdout_hist = ''
+        self.stdout_hist = ''  # str (bytes in Py2, unicode in Py3)
         self.list_win = newwin(get_colpair(config, 'background'), 1, 1, 1, 1)
         self.cpos = 0
         self.do_exit = False
@@ -1066,13 +1066,19 @@ class CLIRepl(repl.Repl):
         """Show the appropriate Python prompt"""
         if not more:
             self.echo("\x01%s\x03%s" % (self.config.color_scheme['prompt'], self.ps1))
-            self.stdout_hist += self.ps1
+            if py3:
+                self.stdout_hist += self.ps1
+            else:
+                self.stdout_hist += self.ps1.encode(getpreferredencoding())
             self.s_hist.append('\x01%s\x03%s\x04' %
                                (self.config.color_scheme['prompt'], self.ps1))
         else:
             prompt_more_color = self.config.color_scheme['prompt_more']
             self.echo("\x01%s\x03%s" % (prompt_more_color, self.ps2))
-            self.stdout_hist += self.ps2
+            if py3:
+                self.stdout_hist += self.ps2
+            else:
+                self.stdout_hist += self.ps2.encode(getpreferredencoding())
             self.s_hist.append('\x01%s\x03%s\x04' % (prompt_more_color, self.ps2))
 
     def push(self, s, insert_into_history=True):

--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -330,7 +330,7 @@ class CLIRepl(repl.Repl):
         repl.Repl.__init__(self, interp, config)
         self.interp.writetb = self.writetb
         self.scr = scr
-        self.stdout_hist = ''  # str (bytes in Py2, unicode in Py3)
+        self.stdout_hist = ''  # native str (bytes in Py2, unicode in Py3)
         self.list_win = newwin(get_colpair(config, 'background'), 1, 1, 1, 1)
         self.cpos = 0
         self.do_exit = False

--- a/bpython/urwid.py
+++ b/bpython/urwid.py
@@ -596,7 +596,7 @@ class URWIDRepl(repl.Repl):
         self.tooltip = urwid.ListBox(urwid.SimpleListWalker([]))
         self.tooltip.grid = None
         self.overlay = Tooltip(self.listbox, self.tooltip)
-        self.stdout_hist = ''
+        self.stdout_hist = ''  # str (bytes in Py2, unicode in Py3)
 
         self.frame = urwid.Frame(self.overlay)
 
@@ -976,17 +976,17 @@ class URWIDRepl(repl.Repl):
         # input to be the same type, using ascii as encoding. If the
         # caption is bytes this breaks typing non-ascii into bpython.
         if not more:
+            caption = ('prompt', self.ps1)
             if py3:
-                caption = ('prompt', self.ps1)
+                self.stdout_hist += self.ps1
             else:
-                caption = ('prompt', self.ps1.decode(getpreferredencoding()))
-            self.stdout_hist += self.ps1
+                self.stdout_hist += self.ps1.encode(getpreferredencoding())
         else:
+            caption = ('prompt_more', self.ps2)
             if py3:
-                caption = ('prompt_more', self.ps2)
+                self.stdout_hist += self.ps2
             else:
-                caption = ('prompt_more', self.ps2.decode(getpreferredencoding()))
-            self.stdout_hist += self.ps2
+                self.stdout_hist += self.ps2.encode(getpreferredencoding())
         self.edit = BPythonEdit(self.config, caption=caption)
 
         urwid.connect_signal(self.edit, 'change', self.on_input_change)

--- a/bpython/urwid.py
+++ b/bpython/urwid.py
@@ -596,7 +596,7 @@ class URWIDRepl(repl.Repl):
         self.tooltip = urwid.ListBox(urwid.SimpleListWalker([]))
         self.tooltip.grid = None
         self.overlay = Tooltip(self.listbox, self.tooltip)
-        self.stdout_hist = ''  # str (bytes in Py2, unicode in Py3)
+        self.stdout_hist = ''  # native str (bytes in Py2, unicode in Py3)
 
         self.frame = urwid.Frame(self.overlay)
 


### PR DESCRIPTION
fixes #701 

Make it clear with comments that self.stdout_hist is bytes in Python 2, unicode in Python 3. Blech, would be nice to fix that to be unicode everywhere.

To debug I made self.stdout_hist a type-checking property, maybe this is worth doing for real? Also maybe static typechecking would be nice? But this PR just fixes this bug.