### PR TITLE
test.test_args: don't hardcode python2

### DIFF
--- a/bpython/test/test_args.py
+++ b/bpython/test/test_args.py
@@ -40,7 +40,7 @@ class TestExecArgs(unittest.TestCase):
     def test_exec_nonascii_file(self):
         with tempfile.NamedTemporaryFile(mode="w") as f:
             f.write(dedent('''\
-                #!/usr/bin/env python2
+                #!/usr/bin/env python
                 # coding: utf-8
                 "你好 # nonascii"
                 '''))
@@ -55,7 +55,7 @@ class TestExecArgs(unittest.TestCase):
     def test_exec_nonascii_file_linenums(self):
         with tempfile.NamedTemporaryFile(mode="w") as f:
             f.write(dedent("""\
-                #!/usr/bin/env python2
+                #!/usr/bin/env python
                 # coding: utf-8
                 1/0
                 """))


### PR DESCRIPTION
This will use python3 in a python3 env and python2 in a python2 one.

found while debugging #712.