### PR TITLE
WIP - width aware output take 2

### DIFF
--- a/bpython/curtsiesfrontend/replpainter.py
+++ b/bpython/curtsiesfrontend/replpainter.py
@@ -25,12 +25,10 @@ def display_linize(msg, columns, blank_line=False):
     """Returns lines obtained by splitting msg over multiple lines.
 
     Warning: if msg is empty, returns an empty list of lines"""
-    display_lines = ([msg[start:end]
-                      for start, end in zip(
-                          range(0, len(msg), columns),
-                          range(columns, len(msg) + columns, columns))]
-                     if msg else ([''] if blank_line else []))
-    return display_lines
+    if not msg:
+        return [''] if blank_line else []
+    msg = fmtstr(msg)
+    return list(msg.width_aware_splitlines(columns))
 
 
 def paint_history(rows, columns, display_lines):

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ classifiers = [
 install_requires = [
     'pygments',
     'requests',
-    'curtsies >=0.1.18',
+    'curtsies >=0.3.0',
     'greenlet',
     'six >=1.5'
 ]


### PR DESCRIPTION
The Curtsies version referenced does not exist yet, don't merge.

Perf looks better now, a linear 10x slower. Wonder if this is good enough, I made some guesses about how to make things fast in https://github.com/bpython/curtsies/pull/109 but haven't profiled at all.

<img width="707" alt="betterperf" src="https://user-images.githubusercontent.com/458879/36171432-850d95b2-10b7-11e8-837d-19205c2cc961.png">
