### PR TITLE
Fix bpython-curses bug when passed an argument

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -81,6 +81,7 @@ from . import translations
 from .translations import _
 
 from . import repl
+from . import args as bpargs
 from ._py3compat import py3
 from .pager import page
 from .args import parse as argsparse
@@ -1914,7 +1915,7 @@ def main_curses(scr, args, config, interactive=True, locals_=None,
     if args:
         exit_value = ()
         try:
-            bpython.args.exec_code(interpreter, args)
+            bpargs.exec_code(interpreter, args)
         except SystemExit as e:
             # The documentation of code.InteractiveInterpreter.runcode claims
             # that it reraises SystemExit. However, I can't manage to trigger


### PR DESCRIPTION
Currently, running `bpython-curses -i file.py` results in:

```
...
  File ".local/share/virtualenvs/flask-ex-03Wix3mp/lib/python3.6/site-packages/bpython/cli.py", line 1905, in main_curses
    bpython.args.exec_code(interpreter, args)
NameError: name 'bpython' is not defined
```

This PR addresses this error by correctly importing args and using it,
like the curtsies implementation.