### PR TITLE
Travis workaround to enable CI with python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7"
+    - "3.7-dev"
     - "3.8-dev"
     - "pypy"
     - "pypy3"
@@ -20,6 +20,7 @@ env:
 
 matrix:
     allow_failures:
+        - python: "3.7-dev"
         - python: "3.8-dev"
         - python: "pypy"
         - python: "pypy3"


### PR DESCRIPTION
Currently, all the python3.7 tests fail on travis because of https://github.com/travis-ci/travis-ci/issues/9069. I adjusted .travis.yml as recommended by TravisCI developer BanzaiMan in https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905.