### PR TITLE
Display the correct signature for a decorated function in Python 3

### DIFF
--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -259,7 +259,7 @@ def getfuncprops(func, f):
             argspec = argspec + [list(), dict(), None]
         argspec = ArgSpec(*argspec)
         fprops = FuncProps(func, argspec, is_bound_method)
-    except (TypeError, KeyError):
+    except (TypeError, KeyError, ValueError):
         with AttrCleaner(f):
             argspec = getpydocspec(f, func)
         if argspec is None:

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -304,18 +304,18 @@ def get_argspec_from_signature(f):
         if parameter.annotation is not inspect._empty:
             annotations[parameter.name] = parameter.annotation
 
-        if parameter.kind == inspect._ParameterKind.POSITIONAL_OR_KEYWORD:
+        if parameter.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
             args.append(parameter.name)
             if parameter.default is not inspect._empty:
                 defaults.append(parameter.default)
-        elif parameter.kind == inspect._ParameterKind.POSITIONAL_ONLY:
+        elif parameter.kind == inspect.Parameter.POSITIONAL_ONLY:
             args.append(parameter.name)
-        elif parameter.kind == inspect._ParameterKind.VAR_POSITIONAL:
+        elif parameter.kind == inspect.Parameter.VAR_POSITIONAL:
             varargs = parameter.name
-        elif parameter.kind == inspect._ParameterKind.KEYWORD_ONLY:
+        elif parameter.kind == inspect.Parameter.KEYWORD_ONLY:
             kwonly.append(parameter.name)
             kwonly_defaults[parameter.name] = parameter.default
-        elif parameter.kind == inspect._ParameterKind.VAR_KEYWORD:
+        elif parameter.kind == inspect.Parameter.VAR_KEYWORD:
             varkwargs = parameter.name
 
     # inspect.getfullargspec returns None for 'defaults', 'kwonly_defaults' and


### PR DESCRIPTION
This patch changes it so that `inspect.signature` is used instead of
`inspect.getfullargspec` to get a function's signature, when using Python 3.

Python 3.3 introduced the `inspect.signature` function as a new way to get the
signature of a function (as an alternative to `inspect.getargspec` and
`inspect.getfullargspec`).  `inspect.signature` has the advantage that it
preserves the signature of a decorated function if `functools.wraps` is used to
decorated the wrapper function.  Having a function's signature available is very
hepful, especially when testing things out in a REPL.

The below images show the change in action (first the old behavior, then the new one):

![old](https://user-images.githubusercontent.com/6815085/52898292-2e3fa580-31dc-11e9-8a30-ba41a79b3485.png)

![new](https://user-images.githubusercontent.com/6815085/52898293-37c90d80-31dc-11e9-87d3-c25e8f4d7482.png)

I was only able to test the changes on Python 3.7.2, but since all used functionality is available since Python 3.3 (and I only touch code paths used on Python 3) I don't think anything should break on other versions.
