### PR TITLE
10x the too low hist_length default of 100 to 1000

### DIFF
--- a/bpython/config.py
+++ b/bpython/config.py
@@ -77,7 +77,7 @@ def loadini(struct, configfile):
             'highlight_show_source': True,
             'hist_duplicates': True,
             'hist_file': '~/.pythonhist',
-            'hist_length': 100,
+            'hist_length': 1000,
             'paste_time': 0.02,
             'pastebin_confirm': True,
             'pastebin_expiry': '1week',


### PR DESCRIPTION
I just lost a useful function I wrote that I hoped I could find in the history file.
a **utf-8** encoded history file having 1000 lines of code _less_ that 80 columns/characters long _less_ than 1000 * 80* **1** /1000=**~80** kilobytes in size.
or is the concern more about the look up time for autocomplete and the responsiveness of typing?