### PR TITLE
Add test case for accessing the history file

### DIFF
--- a/bpython/test/test_history.py
+++ b/bpython/test/test_history.py
@@ -94,7 +94,7 @@ class TestHistoryFileAccess(unittest.TestCase):
 
         with io.open(self.filename, 'w', encoding=self.encoding,
                      errors='ignore') as f:
-            f.write('#1\n#2\n')
+            f.write(b'#1\n#2\n'.decode())
 
     def test_load(self):
         history = History()

--- a/bpython/test/test_history.py
+++ b/bpython/test/test_history.py
@@ -112,7 +112,10 @@ class TestHistoryFileAccess(unittest.TestCase):
         self.assertEqual(history.entries, ['#1', '#2', '#3', '#4'])
 
     def test_save(self):
-        history = History(['#1', '#2', '#3', '#4'])
+        history = History()
+        history.entries = []
+        for line in ['#1', '#2', '#3', '#4']:
+            history.append_to(history.entries, line)
 
         # save only last 2 lines
         history.save(self.filename, self.encoding, lines=2)


### PR DESCRIPTION
I divided the changes from #781 into two branches. This is the additional test case that I branched into `test-hist-file`.