### PR TITLE
Support packages that are using the new importlib.metadata api

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -274,6 +274,16 @@ class ImportFinder(object):
         self.watcher = watcher
         self.old_meta_path = old_meta_path
 
+    def find_distributions(self, context):
+        for finder in self.old_meta_path:
+            distribution_finder = getattr(finder, 'find_distributions', None)
+            if distribution_finder is not None:
+                loader = finder.find_distributions(context)
+                if loader is not None:
+                    return loader
+
+        return None
+
     def find_module(self, fullname, path=None):
         for finder in self.old_meta_path:
             loader = finder.find_module(fullname, path)


### PR DESCRIPTION
Fix issue #807 that I've opened.
The bug is as follows:
Some new python3.8 compatible packages are using the new importlib.metadata package instead of the now-old pkg_resources.
it has a new api, and it breaks inside bpython if "self.watcher" isn't None.
(Frankly I didn't invest the time to look what this "self.watcher" is.
I've just added the required api functionality for the imports to work.
