### PR TITLE
Don't pollute history with duplicate entries during reload-and-clear-modules

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1035,7 +1035,7 @@ class BaseRepl(BpythonRepl):
         cursor, line = self.cursor_offset, self.current_line
         for modname in set(sys.modules.keys()) - self.original_modules:
             del sys.modules[modname]
-        self.reevaluate(new_code=True)
+        self.reevaluate(new_code=False)
         self.cursor_offset, self.current_line = cursor, line
         self.status_bar.message(
             _("Reloaded at %s by user.") % (time.strftime("%X"),)


### PR DESCRIPTION
Made small change in repl.py -- self.reevaluate(new_code=False) rather than True now.