### PR TITLE
Corrected cursor positioning on inputs with full-width (2 column) characters

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -19,6 +19,8 @@ from pygments import format as pygformat
 from bpython._py3compat import PythonLexer
 from pygments.formatters import TerminalFormatter
 
+from wcwidth import wcswidth
+
 import blessings
 
 import curtsies
@@ -1556,7 +1558,8 @@ class BaseRepl(BpythonRepl):
 
         if self.stdin.has_focus:
             cursor_row, cursor_column = divmod(
-                len(self.current_stdouterr_line) + self.stdin.cursor_offset,
+                len(self.current_stdouterr_line)
+                + wcswidth(self.stdin.current_line[: self.stdin.cursor_offset]),
                 width,
             )
             assert cursor_column >= 0, cursor_column
@@ -1577,9 +1580,9 @@ class BaseRepl(BpythonRepl):
         else:
             cursor_row, cursor_column = divmod(
                 (
-                    len(self.current_cursor_line_without_suggestion)
-                    - len(self.current_line)
-                    + self.cursor_offset
+                    self.current_cursor_line_without_suggestion.width
+                    - wcswidth(self.current_line)
+                    + wcswidth(self.current_line[: self.cursor_offset]) 
                 ),
                 width,
             )

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1361,7 +1361,11 @@ class BaseRepl(BpythonRepl):
 
     @property
     def current_cursor_line_without_suggestion(self):
-        """Current line, either output/input or Python prompt + code"""
+        """
+        Current line, either output/input or Python prompt + code
+
+        :returns: FmtStr
+        """
         value = self.current_output_line + (
             "" if self.coderunner.running else self.display_line_with_prompt
         )
@@ -1577,10 +1581,10 @@ class BaseRepl(BpythonRepl):
                 len(self.current_line),
                 self.cursor_offset,
             )
-        else:
+        else: # Common case for determining cursor position
             cursor_row, cursor_column = divmod(
                 (
-                    self.current_cursor_line_without_suggestion.width
+                    wcswidth(self.current_cursor_line_without_suggestion.s)
                     - wcswidth(self.current_line)
                     + wcswidth(self.current_line[: self.cursor_offset]) 
                 ),

--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1558,7 +1558,7 @@ class BaseRepl(BpythonRepl):
 
         if self.stdin.has_focus:
             cursor_row, cursor_column = divmod(
-                len(self.current_stdouterr_line)
+                wcswidth(self.current_stdouterr_line)
                 + wcswidth(self.stdin.current_line[: self.stdin.cursor_offset]),
                 width,
             )

--- a/setup.py
+++ b/setup.py
@@ -225,9 +225,10 @@ classifiers = [
 install_requires = [
     "pygments",
     "requests",
-    "curtsies >=0.2.0",
+    "curtsies >=0.1.18",
     "greenlet",
     "six >=1.5",
+    "wcwidth"
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ classifiers = [
 install_requires = [
     "pygments",
     "requests",
-    "curtsies >=0.1.18",
+    "curtsies >=0.2.0",
     "greenlet",
     "six >=1.5",
 ]


### PR DESCRIPTION
This addresses issue #749. It should now be fixed for normal input as well as stdin input.

Before:
![widetextbefore](https://user-images.githubusercontent.com/48132522/86290120-81887d00-bbb2-11ea-95cf-99614647aaff.png)

After:
![widetextafter](https://user-images.githubusercontent.com/48132522/86290111-7e8d8c80-bbb2-11ea-9984-f8ab82335e84.png)

Also, because the issue with width aware text wrapping still exists (#731), it gets a little weird when you exceed one line. Still, I think the cursor is in the correct spot. In the below example the un-wrapped part is '６７８９０'. The cursor seems right despite the text not wrapping.
![widetextwrap](https://user-images.githubusercontent.com/48132522/86291210-471fdf80-bbb4-11ea-880e-2b4980a4b008.png)
