### PR TITLE
Fix long lines sent to editor

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -20,7 +20,6 @@ from bpython._py3compat import PythonLexer
 from pygments.formatters import TerminalFormatter
 
 from wcwidth import wcswidth
-from math import ceil
 
 import blessings
 
@@ -1009,18 +1008,10 @@ class BaseRepl(BpythonRepl):
 
     def send_session_to_external_editor(self, filename=None):
         """
-        Sends entire bpython session to external editor to be edited. Usually bound to F7. 
-
-        Loops through self.all_logical_lines so that lines aren't wrapped in the editor.
-        
+        Sends entire bpython session to external editor to be edited. Usually bound to F7.         
         """
         for_editor = EDIT_SESSION_HEADER
-        for_editor += "\n".join(
-            line[0] if line[1] == INPUT
-            else "### " + line[0] 
-            for line in self.all_logical_lines
-        )
-        for_editor += "\n" + "### " + self.current_line
+        for_editor += self.get_session_formatted_for_file()
 
         text = self.send_to_external_editor(for_editor)
         if text == for_editor:
@@ -1035,7 +1026,7 @@ class BaseRepl(BpythonRepl):
             current_line = lines[-1][4:]
         else:
             current_line = ""
-        from_editor = [line for line in lines if line[:3] != "###"]
+        from_editor = [line for line in lines if line[:6] != "# OUT:"]
         if all(not line.strip() for line in from_editor):
             self.status_bar.message(
                 _("Session not reevaluated because saved file was blank")
@@ -1938,7 +1929,7 @@ class BaseRepl(BpythonRepl):
 
     def getstdout(self):
         """
-        Returns a string of the current bpython session, formatted and wrapped.
+        Returns a string of the current bpython session, wrapped, WITH prompts.
         """
         lines = self.lines_for_display + [self.current_line_formatted]
         s = (

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -41,6 +41,7 @@ import traceback
 from itertools import takewhile
 from six import itervalues
 from types import ModuleType
+from enum import Enum
 
 from pygments.token import Token
 
@@ -387,6 +388,11 @@ class Interaction(object):
 class SourceNotFound(Exception):
     """Exception raised when the requested source could not be found."""
 
+class LineTypeTranslator(Enum):
+    """ Used when adding a tuple to all_logical_lines, to get input / output values
+    having to actually type/know the strings """
+    INPUT = "input"
+    OUTPUT = "output"
 
 class Repl(object):
     """Implements the necessary guff for a Python-repl-alike interface
@@ -821,11 +827,9 @@ class Repl(object):
         output lines."""
 
         def process():
-            for line in session_ouput.split("\n"):
-                if line.startswith(self.ps1):
-                    yield line[len(self.ps1) :]
-                elif line.startswith(self.ps2):
-                    yield line[len(self.ps2) :]
+            for line, lineType in self.all_logical_lines:
+                if lineType == LineTypeTranslator.INPUT:
+                    yield line
                 elif line.rstrip():
                     yield "# OUT: %s" % (line,)
 

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -821,18 +821,18 @@ class Repl(object):
             indentation = 0
         return indentation
 
-    def formatforfile(self, session_ouput):
+    def get_session_formatted_for_file(self):
         """Format the stdout buffer to something suitable for writing to disk,
         i.e. without >>> and ... at input lines and with "# OUT: " prepended to
-        output lines."""
+        output lines and "### " prepended to current line"""
 
         def process():
             for line, lineType in self.all_logical_lines:
                 if lineType == LineTypeTranslator.INPUT:
                     yield line
                 elif line.rstrip():
-                    yield "# OUT: %s" % (line,)
-
+                    yield "# OUT: %s" % line
+            yield "###: %s" % self.current_line
         return "\n".join(process())
 
     def write2file(self):
@@ -872,7 +872,7 @@ class Repl(object):
                 self.interact.notify(_("Save cancelled."))
                 return
 
-        stdout_text = self.formatforfile(self.getstdout())
+        stdout_text = self.get_session_formatted_for_file()
 
         try:
             with open(fn, mode) as f:
@@ -889,7 +889,7 @@ class Repl(object):
             self.interact.notify(_("No clipboard available."))
             return
 
-        content = self.formatforfile(self.getstdout())
+        content = self.get_session_formatted_for_file()
         try:
             self.clipboard.copy(content)
         except CopyFailed:

--- a/bpython/test/test_curtsies_repl.py
+++ b/bpython/test/test_curtsies_repl.py
@@ -13,6 +13,7 @@ from six.moves import StringIO
 from bpython.curtsiesfrontend import repl as curtsiesrepl
 from bpython.curtsiesfrontend import interpreter
 from bpython.curtsiesfrontend import events as bpythonevents
+from bpython.repl import LineTypeTranslator as LineType
 from bpython import autocomplete
 from bpython import config
 from bpython import args
@@ -79,7 +80,7 @@ class TestCurtsiesRepl(TestCase):
         with captured_output():
             self.repl.display_lines.append('>>> "åß∂ƒ"')
             self.repl.history.append('"åß∂ƒ"')
-            self.repl.all_logical_lines.append(('"åß∂ƒ"',"input"))
+            self.repl.all_logical_lines.append(('"åß∂ƒ"', LineType.INPUT))
             self.repl.send_session_to_external_editor()
 
     def test_get_last_word(self):

--- a/bpython/test/test_curtsies_repl.py
+++ b/bpython/test/test_curtsies_repl.py
@@ -78,6 +78,8 @@ class TestCurtsiesRepl(TestCase):
     def test_external_communication_encoding(self):
         with captured_output():
             self.repl.display_lines.append('>>> "åß∂ƒ"')
+            self.repl.history.append('"åß∂ƒ"')
+            self.repl.all_logical_lines.append(('"åß∂ƒ"',"input"))
             self.repl.send_session_to_external_editor()
 
     def test_get_last_word(self):


### PR DESCRIPTION
This is a working fix to #727, where long lines sent to the editor (usually with F7) are cut off and can't be edited correctly.

From what I can tell, the solution seems to work fine, but since this is the most code I've written at once for bpython, I want to make sure the structure / conventions / methods are valid. So I'll start it as a draft.