### PR TITLE
Fix issue returning from editor

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -1026,7 +1026,7 @@ class BaseRepl(BpythonRepl):
             current_line = lines[-1][4:]
         else:
             current_line = ""
-        from_editor = [line for line in lines if line[:6] != "# OUT:"]
+        from_editor = [line for line in lines if line[:6] != "# OUT:" and line[:3] != "###"]
         if all(not line.strip() for line in from_editor):
             self.status_bar.message(
                 _("Session not reevaluated because saved file was blank")

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -835,7 +835,7 @@ class Repl(object):
                     yield line
                 elif line.rstrip():
                     yield "# OUT: %s" % line
-            yield "###: %s" % self.current_line
+            yield "### %s" % self.current_line
 
         return "\n".join(process())
 


### PR DESCRIPTION
Small fix on a issue returning from editor which occurs after some changes I made to the commenting style on my last commit.

Side note: is it fine that some non-input lines in the editor session start with "# OUT:" and others with "### "? I think it's helpful for clarity, but I recognize that having the same prefix for all line is consistent.