### PR TITLE
Refactoring to start using getattr_static

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -340,9 +340,6 @@ class AttrCompletion(BaseCompletionType):
         """Taken from rlcompleter.py and bent to my will.
         """
 
-        # Gna, Py 2.6's rlcompleter searches for __call__ inside the
-        # instance instead of the type, so we monkeypatch to prevent
-        # side-effects (__getattr__/__getattribute__)
         m = self.attr_matches_re.match(text)
         if not m:
             return []
@@ -364,7 +361,7 @@ class AttrCompletion(BaseCompletionType):
         be wrapped in a safe try/finally block in case anything bad happens to
         restore the original __getattribute__ method."""
         words = self.list_attributes(obj)
-        if inspection.has_attr_safe(obj, "__class__"):
+        if inspection.hasattr_safe(obj, "__class__"):
             words.append("__class__")
             words = words + rlcompleter.get_class_members(obj.__class__)
             if not isinstance(obj.__class__, abc.ABCMeta):
@@ -537,7 +534,7 @@ class ExpressionAttributeCompletion(AttrCompletion):
         except EvaluationError:
             return set()
 
-        # strips leading dot
+         #        strips leading dot
         matches = [m[1:] for m in self.attr_lookup(obj, "", attr.word)]
         return set(m for m in matches if few_enough_underscores(attr.word, m))
 
@@ -677,7 +674,6 @@ def get_completer_bpython(cursor_offset, line, **kwargs):
 
 def _callable_postfix(value, word):
     """rlcompleter's _callable_postfix done right."""
-    # TODO: do we need this done within an AttrCleaner?
     if inspection.is_callable(value):
         word += "("
     return word

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -33,6 +33,7 @@ from collections import namedtuple
 from six.moves import range
 
 from pygments.token import Token
+from types import MemberDescriptorType
 
 from ._py3compat import PythonLexer, py3
 from .lazyre import LazyReCompile
@@ -214,7 +215,7 @@ def getpydocspec(f, func):
     if s is None:
         return None
 
-    if not hasattr(f, "__name__") or s.groups()[0] != f.__name__:
+    if not has_attr_safe(f, "__name__") or s.groups()[0] != f.__name__:
         return None
 
     args = list()
@@ -276,8 +277,7 @@ def getfuncprops(func, f):
         argspec = ArgSpec(*argspec)
         fprops = FuncProps(func, argspec, is_bound_method)
     except (TypeError, KeyError, ValueError):
-        with AttrCleaner(f):
-            argspec = getpydocspec(f, func)
+        argspec = getpydocspec(f, func)
         if argspec is None:
             return None
         if inspect.ismethoddescriptor(f):
@@ -390,6 +390,47 @@ def get_encoding_file(fname):
             if match:
                 return match.group(1)
     return "ascii"
+
+
+if not py3:
+
+    def get_attr_safe(obj, name):
+        """side effect free getattr"""
+        if not is_new_style(obj):
+            return getattr(obj, name)
+
+        with AttrCleaner(obj):
+            to_look_through = (
+                obj.__mro__
+                if inspect.isclass(obj)
+                else (obj,) + type(obj).__mro__
+            )
+            for cls in to_look_through:
+                if hasattr(cls, "__dict__") and name in cls.__dict__:
+                    result = cls.__dict__[name]
+                    if isinstance(result, MemberDescriptorType):
+                        result = getattr(obj, name)
+                    return result
+            raise AttributeError(name)
+
+
+else:
+
+    def get_attr_safe(obj, name):
+        """side effect and AttrCleaner free getattr (calls getattr_static)."""
+        result = inspect.getattr_static(obj, name)
+        # Slots are a MemberDescriptorType
+        if isinstance(result, MemberDescriptorType):
+            result = getattr(obj, name)
+        return result
+
+
+def has_attr_safe(obj, name):
+    try:
+        get_attr_safe(obj, name)
+        return True
+    except AttributeError:
+        return False
 
 
 if py3:

--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -215,7 +215,7 @@ def getpydocspec(f, func):
     if s is None:
         return None
 
-    if not has_attr_safe(f, "__name__") or s.groups()[0] != f.__name__:
+    if not hasattr_safe(f, "__name__") or s.groups()[0] != f.__name__:
         return None
 
     args = list()
@@ -394,7 +394,7 @@ def get_encoding_file(fname):
 
 if not py3:
 
-    def get_attr_safe(obj, name):
+    def getattr_safe(obj, name):
         """side effect free getattr"""
         if not is_new_style(obj):
             return getattr(obj, name)
@@ -416,8 +416,8 @@ if not py3:
 
 else:
 
-    def get_attr_safe(obj, name):
-        """side effect and AttrCleaner free getattr (calls getattr_static)."""
+    def getattr_safe(obj, name):
+        """side effect free getattr (calls getattr_static)."""
         result = inspect.getattr_static(obj, name)
         # Slots are a MemberDescriptorType
         if isinstance(result, MemberDescriptorType):
@@ -425,9 +425,9 @@ else:
         return result
 
 
-def has_attr_safe(obj, name):
+def hasattr_safe(obj, name):
     try:
-        get_attr_safe(obj, name)
+        getattr_safe(obj, name)
         return True
     except AttributeError:
         return False

--- a/bpython/simpleeval.py
+++ b/bpython/simpleeval.py
@@ -38,7 +38,7 @@ from six.moves import builtins
 
 from . import line as line_properties
 from ._py3compat import py3
-from .inspection import is_new_style, AttrCleaner
+from .inspection import get_attr_safe
 
 _string_type_nodes = (ast.Str, ast.Bytes) if py3 else (ast.Str,)
 _numeric_types = (int, float, complex) + (() if py3 else (long,))
@@ -163,7 +163,7 @@ def simple_eval(node_or_string, namespace=None):
         if isinstance(node, ast.Attribute):
             obj = _convert(node.value)
             attr = node.attr
-            return safe_get_attribute(obj, attr)
+            return get_attr_safe(obj, attr)
 
         raise ValueError("malformed string")
 
@@ -171,6 +171,7 @@ def simple_eval(node_or_string, namespace=None):
 
 
 def safe_getitem(obj, index):
+    """ Safely tries to access obj[index] """
     if type(obj) in (list, tuple, dict, bytes) + string_types:
         try:
             return obj[index]
@@ -251,44 +252,3 @@ def evaluate_current_attribute(cursor_offset, line, namespace=None):
             "can't lookup attribute %s on %r" % (attr.word, obj)
         )
 
-
-def safe_get_attribute(obj, attr):
-    """Gets attributes without triggering descriptors on new-style classes"""
-    if is_new_style(obj):
-        with AttrCleaner(obj):
-            result = safe_get_attribute_new_style(obj, attr)
-            if isinstance(result, member_descriptor):
-                # will either be the same slot descriptor or the value
-                return getattr(obj, attr)
-            return result
-    return getattr(obj, attr)
-
-
-class _ClassWithSlots(object):
-    __slots__ = ["a"]
-
-
-member_descriptor = type(_ClassWithSlots.a)
-
-
-def safe_get_attribute_new_style(obj, attr):
-    """Returns approximately the attribute returned by getattr(obj, attr)
-
-    The object returned ought to be callable if getattr(obj, attr) was.
-    Fake callable objects may be returned instead, in order to avoid executing
-    arbitrary code in descriptors.
-
-    If the object is an instance of a class that uses __slots__, will return
-    the member_descriptor object instead of the value.
-    """
-    if not is_new_style(obj):
-        raise ValueError("%r is not a new-style class or object" % obj)
-    to_look_through = (
-        obj.__mro__ if inspect.isclass(obj) else (obj,) + type(obj).__mro__
-    )
-
-    for cls in to_look_through:
-        if hasattr(cls, "__dict__") and attr in cls.__dict__:
-            return cls.__dict__[attr]
-
-    raise AttributeError()

--- a/bpython/simpleeval.py
+++ b/bpython/simpleeval.py
@@ -38,7 +38,7 @@ from six.moves import builtins
 
 from . import line as line_properties
 from ._py3compat import py3
-from .inspection import get_attr_safe
+from .inspection import getattr_safe
 
 _string_type_nodes = (ast.Str, ast.Bytes) if py3 else (ast.Str,)
 _numeric_types = (int, float, complex) + (() if py3 else (long,))
@@ -163,7 +163,7 @@ def simple_eval(node_or_string, namespace=None):
         if isinstance(node, ast.Attribute):
             obj = _convert(node.value)
             attr = node.attr
-            return get_attr_safe(obj, attr)
+            return getattr_safe(obj, attr)
 
         raise ValueError("malformed string")
 

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -251,6 +251,9 @@ class Properties(Foo):
 class Slots(object):
     __slots__ = ["a", "b"]
 
+class OverriddenGetattribute(Foo):
+    def __getattribute__(self,name):
+        raise AssertionError("custom get attribute invoked")
 
 class TestAttrCompletion(unittest.TestCase):
     @classmethod
@@ -298,12 +301,20 @@ class TestAttrCompletion(unittest.TestCase):
             com.matches(2, "a.", locals_={"a": Properties()}),
             set(["a.b", "a.a", "a.method", "a.asserts_when_called"]),
         )
+        
+    def test_custom_get_attribute_not_invoked(self):
+        com = autocomplete.AttrCompletion()
+        self.assertSetEqual(
+            com.matches(2, "a.", locals_={"a": OverriddenGetattribute()}),
+            set(["a.b", "a.a", "a.method"]),
+        )
+
 
     def test_slots_not_crash(self):
         com = autocomplete.AttrCompletion()
         self.assertSetEqual(
             com.matches(2, "A.", locals_={"A": Slots}),
-            set(["A.b", "A.a", "A.mro"]),
+            set(["A.b", "A.a"]),
         )
 
 

--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -159,43 +159,53 @@ class TestInspection(unittest.TestCase):
         def test_lookup_on_object(self):
             a = A()
             a.x = 1
-            self.assertEqual(get_attr_safe(a, "x"), 1)
-            self.assertEqual(get_attr_safe(a, "a"), "a")
+            self.assertEqual(getattr_safe(a, "x"), 1)
+            self.assertEqual(getattr_safe(a, "a"), "a")
             b = B()
             b.y = 2
-            self.assertEqual(get_attr_safe(b, "y"), 2)
-            self.assertEqual(get_attr_safe(b, "a"), "a")
-            self.assertEqual(get_attr_safe(b, "b"), "b")
+            self.assertEqual(getattr_safe(b, "y"), 2)
+            self.assertEqual(getattr_safe(b, "a"), "a")
+            self.assertEqual(getattr_safe(b, "b"), "b")
+
+            self.assertEqual(hasattr_safe(b, "y"), True)
+            self.assertEqual(hasattr_safe(b, "b"), True)
+
 
         def test_avoid_running_properties(self):
             p = Property()
-            self.assertEqual(get_attr_safe(p, "prop"), Property.prop)
+            self.assertEqual(getattr_safe(p, "prop"), Property.prop)
+            self.assertEqual(hasattr_safe(p, "prop"), True)
         
         def test_lookup_with_slots(self):
             s = Slots()
             s.s1 = "s1"
-            self.assertEqual(get_attr_safe(s, "s1"), "s1")
+            self.assertEqual(getattr_safe(s, "s1"), "s1")
             with self.assertRaises(AttributeError):
-                get_attr_safe(s, "s2")
+                getattr_safe(s, "s2")
+
+            self.assertEqual(hasattr_safe(s, "s2"), False)
 
         def test_lookup_on_slots_classes(self):
-            sga = get_attr_safe
+            sga = getattr_safe
             s = SlotsSubclass()
             self.assertIsInstance(sga(Slots, "s1"), member_descriptor)
             self.assertIsInstance(sga(SlotsSubclass, "s1"), member_descriptor)
             self.assertIsInstance(sga(SlotsSubclass, "s4"), property)
             self.assertIsInstance(sga(s, "s4"), property)
 
+            self.assertEqual(hasattr_safe(s, "s1"), True)
+            self.assertEqual(hasattr_safe(s, "s4"), True)
+
         @unittest.skipIf(py3, "Py 3 doesn't allow slots and prop in same class")
         def test_lookup_with_property_and_slots(self):
-            sga = get_attr_safe
+            sga = getattr_safe
             s = SlotsSubclass()
             self.assertIsInstance(sga(Slots, "s3"), property)
-            self.assertEqual(get_attr_safe(s, "s3"), Slots.__dict__["s3"])
+            self.assertEqual(getattr_safe(s, "s3"), Slots.__dict__["s3"])
             self.assertIsInstance(sga(SlotsSubclass, "s3"), property)
 
         def test_lookup_on_overridden_methods(self):
-            sga = get_attr_safe
+            sga = getattr_safe
             self.assertEqual(sga(OverriddenGetattr(), "a"), 1)
             self.assertEqual(sga(OverriddenGetattribute(), "a"), 1)
             self.assertEqual(sga(OverriddenMRO(), "a"), 1)
@@ -205,6 +215,12 @@ class TestInspection(unittest.TestCase):
                 sga(OverriddenGetattribute(), "b")
             with self.assertRaises(AttributeError):
                 sga(OverriddenMRO(), "b")
+
+            self.assertEqual(hasattr_safe(OverriddenGetattr(), "b"), False)
+            self.assertEqual(hasattr_safe(OverriddenGetattribute(), "b"), False)
+            self.assertEqual(hasattr_safe(OverriddenMRO(), "b"), False)
+            
+
 
 
 if __name__ == "__main__":

--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -155,73 +155,124 @@ class TestInspection(unittest.TestCase):
         self.assertEqual(encoding, "utf-8")
 
 
-    class TestSafeGetAttribute(unittest.TestCase):
-        def test_lookup_on_object(self):
-            a = A()
-            a.x = 1
-            self.assertEqual(getattr_safe(a, "x"), 1)
-            self.assertEqual(getattr_safe(a, "a"), "a")
-            b = B()
-            b.y = 2
-            self.assertEqual(getattr_safe(b, "y"), 2)
-            self.assertEqual(getattr_safe(b, "a"), "a")
-            self.assertEqual(getattr_safe(b, "b"), "b")
-
-            self.assertEqual(hasattr_safe(b, "y"), True)
-            self.assertEqual(hasattr_safe(b, "b"), True)
+class A(object):
+    a = "a"
 
 
-        def test_avoid_running_properties(self):
-            p = Property()
-            self.assertEqual(getattr_safe(p, "prop"), Property.prop)
-            self.assertEqual(hasattr_safe(p, "prop"), True)
+class B(A):
+    b = "b"
+
+
+class Property(object):
+    @property
+    def prop(self):
+        raise AssertionError("Property __get__ executed")
+
+
+class Slots(object):
+    __slots__ = ["s1", "s2", "s3"]
+
+    if not py3:
+
+        @property
+        def s3(self):
+            raise AssertionError("Property __get__ executed")
+
+
+class SlotsSubclass(Slots):
+    @property
+    def s4(self):
+        raise AssertionError("Property __get__ executed")
+
+
+class OverriddenGetattr(object):
+    def __getattr__(self, attr):
+        raise AssertionError("custom __getattr__ executed")
+
+    a = 1
+
+
+class OverriddenGetattribute(object):
+    def __getattribute__(self, attr):
+        raise AssertionError("custom __getattribute__ executed")
+
+    a = 1
+
+
+class OverriddenMRO(object):
+    def __mro__(self):
+        raise AssertionError("custom mro executed")
+
+    a = 1
+    
+member_descriptor = type(Slots.s1)
+
+class TestSafeGetAttribute(unittest.TestCase):
+    def test_lookup_on_object(self):
+        a = A()
+        a.x = 1
+        self.assertEqual(inspection.getattr_safe(a, "x"), 1)
+        self.assertEqual(inspection.getattr_safe(a, "a"), "a")
+        b = B()
+        b.y = 2
+        self.assertEqual(inspection.getattr_safe(b, "y"), 2)
+        self.assertEqual(inspection.getattr_safe(b, "a"), "a")
+        self.assertEqual(inspection.getattr_safe(b, "b"), "b")
+
+        self.assertEqual(inspection.hasattr_safe(b, "y"), True)
+        self.assertEqual(inspection.hasattr_safe(b, "b"), True)
+
+
+    def test_avoid_running_properties(self):
+        p = Property()
+        self.assertEqual(inspection.getattr_safe(p, "prop"), Property.prop)
+        self.assertEqual(inspection.hasattr_safe(p, "prop"), True)
+    
+    def test_lookup_with_slots(self):
+        s = Slots()
+        s.s1 = "s1"
+        self.assertEqual(inspection.getattr_safe(s, "s1"), "s1")
+        with self.assertRaises(AttributeError):
+            inspection.getattr_safe(s, "s2")
+
+        self.assertEqual(inspection.hasattr_safe(s, "s1"), True)
+        self.assertEqual(inspection.hasattr_safe(s, "s2"), False)
+
+    def test_lookup_on_slots_classes(self):
+        sga = inspection.getattr_safe
+        s = SlotsSubclass()
+        self.assertIsInstance(sga(Slots, "s1"), member_descriptor)
+        self.assertIsInstance(sga(SlotsSubclass, "s1"), member_descriptor)
+        self.assertIsInstance(sga(SlotsSubclass, "s4"), property)
+        self.assertIsInstance(sga(s, "s4"), property)
+
+        self.assertEqual(inspection.hasattr_safe(s, "s1"), False)
+        self.assertEqual(inspection.hasattr_safe(s, "s4"), True)
+
+    @unittest.skipIf(py3, "Py 3 doesn't allow slots and prop in same class")
+    def test_lookup_with_property_and_slots(self):
+        sga = inspection.getattr_safe
+        s = SlotsSubclass()
+        self.assertIsInstance(sga(Slots, "s3"), property)
+        self.assertEqual(inspection.getattr_safe(s, "s3"), Slots.__dict__["s3"])
+        self.assertIsInstance(sga(SlotsSubclass, "s3"), property)
+
+    def test_lookup_on_overridden_methods(self):
+        sga = inspection.getattr_safe
+        self.assertEqual(sga(OverriddenGetattr(), "a"), 1)
+        self.assertEqual(sga(OverriddenGetattribute(), "a"), 1)
+        self.assertEqual(sga(OverriddenMRO(), "a"), 1)
+        with self.assertRaises(AttributeError):
+            sga(OverriddenGetattr(), "b")
+        with self.assertRaises(AttributeError):
+            sga(OverriddenGetattribute(), "b")
+        with self.assertRaises(AttributeError):
+            sga(OverriddenMRO(), "b")
+
+        self.assertEqual(inspection.hasattr_safe(OverriddenGetattr(), "b"), False)
+        self.assertEqual(inspection.hasattr_safe(OverriddenGetattribute(), "b"), False)
+        self.assertEqual(inspection.hasattr_safe(OverriddenMRO(), "b"), False)
         
-        def test_lookup_with_slots(self):
-            s = Slots()
-            s.s1 = "s1"
-            self.assertEqual(getattr_safe(s, "s1"), "s1")
-            with self.assertRaises(AttributeError):
-                getattr_safe(s, "s2")
-
-            self.assertEqual(hasattr_safe(s, "s2"), False)
-
-        def test_lookup_on_slots_classes(self):
-            sga = getattr_safe
-            s = SlotsSubclass()
-            self.assertIsInstance(sga(Slots, "s1"), member_descriptor)
-            self.assertIsInstance(sga(SlotsSubclass, "s1"), member_descriptor)
-            self.assertIsInstance(sga(SlotsSubclass, "s4"), property)
-            self.assertIsInstance(sga(s, "s4"), property)
-
-            self.assertEqual(hasattr_safe(s, "s1"), True)
-            self.assertEqual(hasattr_safe(s, "s4"), True)
-
-        @unittest.skipIf(py3, "Py 3 doesn't allow slots and prop in same class")
-        def test_lookup_with_property_and_slots(self):
-            sga = getattr_safe
-            s = SlotsSubclass()
-            self.assertIsInstance(sga(Slots, "s3"), property)
-            self.assertEqual(getattr_safe(s, "s3"), Slots.__dict__["s3"])
-            self.assertIsInstance(sga(SlotsSubclass, "s3"), property)
-
-        def test_lookup_on_overridden_methods(self):
-            sga = getattr_safe
-            self.assertEqual(sga(OverriddenGetattr(), "a"), 1)
-            self.assertEqual(sga(OverriddenGetattribute(), "a"), 1)
-            self.assertEqual(sga(OverriddenMRO(), "a"), 1)
-            with self.assertRaises(AttributeError):
-                sga(OverriddenGetattr(), "b")
-            with self.assertRaises(AttributeError):
-                sga(OverriddenGetattribute(), "b")
-            with self.assertRaises(AttributeError):
-                sga(OverriddenMRO(), "b")
-
-            self.assertEqual(hasattr_safe(OverriddenGetattr(), "b"), False)
-            self.assertEqual(hasattr_safe(OverriddenGetattribute(), "b"), False)
-            self.assertEqual(hasattr_safe(OverriddenMRO(), "b"), False)
-            
-
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/bpython/test/test_simpleeval.py
+++ b/bpython/test/test_simpleeval.py
@@ -7,8 +7,6 @@ from bpython.simpleeval import (
     simple_eval,
     evaluate_current_expression,
     EvaluationError,
-    safe_get_attribute,
-    safe_get_attribute_new_style,
 )
 from bpython.test import unittest
 from bpython._py3compat import py3
@@ -187,72 +185,6 @@ class OverriddenMRO(object):
 
 
 member_descriptor = type(Slots.s1)
-
-
-class TestSafeGetAttribute(unittest.TestCase):
-    def test_lookup_on_object(self):
-        a = A()
-        a.x = 1
-        self.assertEqual(safe_get_attribute_new_style(a, "x"), 1)
-        self.assertEqual(safe_get_attribute_new_style(a, "a"), "a")
-        b = B()
-        b.y = 2
-        self.assertEqual(safe_get_attribute_new_style(b, "y"), 2)
-        self.assertEqual(safe_get_attribute_new_style(b, "a"), "a")
-        self.assertEqual(safe_get_attribute_new_style(b, "b"), "b")
-
-    def test_avoid_running_properties(self):
-        p = Property()
-        self.assertEqual(safe_get_attribute_new_style(p, "prop"), Property.prop)
-
-    @unittest.skipIf(py3, "Old-style classes not in Python 3")
-    def test_raises_on_old_style_class(self):
-        class Old:
-            pass
-
-        with self.assertRaises(ValueError):
-            safe_get_attribute_new_style(Old, "asdf")
-
-    def test_lookup_with_slots(self):
-        s = Slots()
-        s.s1 = "s1"
-        self.assertEqual(safe_get_attribute(s, "s1"), "s1")
-        self.assertIsInstance(
-            safe_get_attribute_new_style(s, "s1"), member_descriptor
-        )
-        with self.assertRaises(AttributeError):
-            safe_get_attribute(s, "s2")
-        self.assertIsInstance(
-            safe_get_attribute_new_style(s, "s2"), member_descriptor
-        )
-
-    def test_lookup_on_slots_classes(self):
-        sga = safe_get_attribute
-        s = SlotsSubclass()
-        self.assertIsInstance(sga(Slots, "s1"), member_descriptor)
-        self.assertIsInstance(sga(SlotsSubclass, "s1"), member_descriptor)
-        self.assertIsInstance(sga(SlotsSubclass, "s4"), property)
-        self.assertIsInstance(sga(s, "s4"), property)
-
-    @unittest.skipIf(py3, "Py 3 doesn't allow slots and prop in same class")
-    def test_lookup_with_property_and_slots(self):
-        sga = safe_get_attribute
-        s = SlotsSubclass()
-        self.assertIsInstance(sga(Slots, "s3"), property)
-        self.assertEqual(safe_get_attribute(s, "s3"), Slots.__dict__["s3"])
-        self.assertIsInstance(sga(SlotsSubclass, "s3"), property)
-
-    def test_lookup_on_overridden_methods(self):
-        sga = safe_get_attribute
-        self.assertEqual(sga(OverriddenGetattr(), "a"), 1)
-        self.assertEqual(sga(OverriddenGetattribute(), "a"), 1)
-        self.assertEqual(sga(OverriddenMRO(), "a"), 1)
-        with self.assertRaises(AttributeError):
-            sga(OverriddenGetattr(), "b")
-        with self.assertRaises(AttributeError):
-            sga(OverriddenGetattribute(), "b")
-        with self.assertRaises(AttributeError):
-            sga(OverriddenMRO(), "b")
 
 
 if __name__ == "__main__":

--- a/bpython/test/test_simpleeval.py
+++ b/bpython/test/test_simpleeval.py
@@ -133,58 +133,6 @@ class TestEvaluateCurrentExpression(unittest.TestCase):
         self.assertCannotEval("a[1].a|bc", {})
 
 
-class A(object):
-    a = "a"
-
-
-class B(A):
-    b = "b"
-
-
-class Property(object):
-    @property
-    def prop(self):
-        raise AssertionError("Property __get__ executed")
-
-
-class Slots(object):
-    __slots__ = ["s1", "s2", "s3"]
-
-    if not py3:
-
-        @property
-        def s3(self):
-            raise AssertionError("Property __get__ executed")
-
-
-class SlotsSubclass(Slots):
-    @property
-    def s4(self):
-        raise AssertionError("Property __get__ executed")
-
-
-class OverriddenGetattr(object):
-    def __getattr__(self, attr):
-        raise AssertionError("custom __getattr__ executed")
-
-    a = 1
-
-
-class OverriddenGetattribute(object):
-    def __getattribute__(self, attr):
-        raise AssertionError("custom __getattribute__ executed")
-
-    a = 1
-
-
-class OverriddenMRO(object):
-    def __mro__(self):
-        raise AssertionError("custom mro executed")
-
-    a = 1
-
-
-member_descriptor = type(Slots.s1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I wanted to add open parenthesis completion in the suggestion box for callable functions, and I noticed there's some code we can consolidate or remove thanks to python3's `getattr_static` function. #163 mentions this. Here's what I changed.

- Start using getattr_static to avoid using AttrCleaner
- Refactor `safe_get_attribute` and `safe_get_attribute_new_style` from simpleeval.py, into `get_attr_safe` in inspection.py and move the tests from test_simpleeval to test_inspection
- Also add `has_attr_safe` to inspection.py
- Add some tests for has_attr_safe

Once we drop python 2 support, we can delete the python2 definition for `get_attr_safe` at which point AttrCleaner will be hardly used anywhere and can be removed / lightened up.