### PR TITLE
Config editors

### DIFF
--- a/bpython/sample-config
+++ b/bpython/sample-config
@@ -36,7 +36,7 @@
 # color_scheme = default
 
 # External editor to use for editing the current line, block, or full history
-# Options: vi (vim)
+# Examples: vi (vim)
 #          code --wait (VS Code) - in VS Code use the command pallete to:
 #                Shell Command: Install 'code' command in PATH
 #          atom -nw (Atom)

--- a/bpython/sample-config
+++ b/bpython/sample-config
@@ -36,6 +36,10 @@
 # color_scheme = default
 
 # External editor to use for editing the current line, block, or full history
+# Options: vi (vim)
+#          code --wait (VS Code) - in VS Code use the command pallete to:
+#                Shell Command: Install 'code' command in PATH
+#          atom -nw (Atom)
 # Default is to try $EDITOR and $VISUAL, then vi - but if you uncomment
 # the line below that will take precedence
 # editor = vi


### PR DESCRIPTION
Added information on how to use VS Code and Atom as your default external editor. Only tested on Mac.