### PR TITLE
ImportFinder: Support find_spec interface

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -287,6 +287,18 @@ class ImportFinder(object):
 
         return None
 
+    def find_spec(self, fullname, path, target=None):
+        for finder in self.old_meta_path:
+            # Consider the finder only if it implements find_spec
+            if not getattr(finder, "find_spec", None):
+                continue
+            # Attempt to find the spec
+            spec = finder.find_spec(fullname, path, target)
+            if spec is not None:
+                # Patch the loader to enable reloading
+                spec.__loader__ = ImportLoader(self.watcher, spec.__loader__)
+                return spec
+
     def find_module(self, fullname, path=None):
         for finder in self.old_meta_path:
             loader = finder.find_module(fullname, path)


### PR DESCRIPTION
The absence of `ImportFinder` wrapping the `find_spec` method (introduced in Python 3.4), which is a successor to now deprecated `find_module` [0] cause one of the finder classes to not find the namespace package, as it is only detectable using `find_spec`

Implements backwards-compatible logic to support `find_spec` if present in the Finder being wrapped.

Closes #835.

[0] https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder.find_spec