### PR TITLE
bump required curtsies version to 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ classifiers = [
 install_requires = [
     "pygments",
     "requests",
-    "curtsies >=0.1.18",
+    "curtsies >=0.3.0",
     "greenlet",
     "six >=1.5",
     "wcwidth",


### PR DESCRIPTION
Update minimum curtsies from 0.1.18 to 0.3.0 in preparation for introducing width awareness (my next PR).

I'm opening this as a separate PR just to confirm upgrading the version isn't what might bring runtime issues (something which was a concern with #731), and in case we don't end up accepting my next PR.

To start, I found no noticeably difference in runtime between curtsies 0.1.18 and 0.3.0 when printing, pasting, and moving my cursor around on long lines (1,000 to 10,000 chars).