### PR TITLE
Add width awareness to fix wrapping of strings with full width chars

### DIFF
--- a/bpython/curtsiesfrontend/replpainter.py
+++ b/bpython/curtsiesfrontend/replpainter.py
@@ -26,19 +26,23 @@ def display_linize(msg, columns, blank_line=False):
     """Returns lines obtained by splitting msg over multiple lines.
 
     Warning: if msg is empty, returns an empty list of lines"""
-    display_lines = (
-        [
-            msg[start:end]
-            for start, end in zip(
-                range(0, len(msg), columns),
-                range(columns, len(msg) + columns, columns),
-            )
-        ]
-        if msg
-        else ([""] if blank_line else [])
-    )
+    if not msg:
+        return [''] if blank_line else []
+    msg = fmtstr(msg)
+    try:
+        display_lines = list(msg.width_aware_splitlines(columns))
+    # use old method if wcwidth can't determine width of msg
+    except ValueError:
+        display_lines = (	    
+                [	        
+                    msg[start:end]	    
+                    for start, end in zip(	    
+                        range(0, len(msg), columns),	
+                        range(columns, len(msg) + columns, columns),	
+                    )	
+                ]	
+            )	
     return display_lines
-
 
 def paint_history(rows, columns, display_lines):
     lines = []

--- a/bpython/test/test_curtsies_painting.py
+++ b/bpython/test/test_curtsies_painting.py
@@ -271,6 +271,32 @@ class HigherLevelCurtsiesPaintingTest(CurtsiesPaintingTest):
         self.repl.process_event("<SPACE>" if key == " " else key)
         self.repl.paint()  # has some side effects we need to be wary of
 
+class TestWidthAwareness(HigherLevelCurtsiesPaintingTest):
+
+    def test_cursor_position_with_fullwidth_char(self):
+        self.repl.add_normal_character("間")
+
+        cursor_pos = self.repl.paint()[1]
+        self.assertEqual(cursor_pos, (0,6))
+
+    def test_cursor_position_with_padding_char(self):
+        # odd numbered so fullwidth chars don't wrap evenly
+        self.repl.width = 11 
+        [self.repl.add_normal_character(c) for c in "ｗｉｄｔｈ"]
+
+        cursor_pos = self.repl.paint()[1]
+        self.assertEqual(cursor_pos, (1,4))
+
+    def test_display_of_padding_chars(self):
+        self.repl.width = 11 
+        [self.repl.add_normal_character(c) for c in "ｗｉｄｔｈ"]
+
+        self.enter()
+        expected = [
+            '>>> ｗｉｄ ', # <--- note the added trailing space
+            'ｔｈ']
+        result = [d.s for d in self.repl.display_lines[0:2]]
+        self.assertEqual(result, expected) 
 
 class TestCurtsiesRewindRedraw(HigherLevelCurtsiesPaintingTest):
     def test_rewind(self):


### PR DESCRIPTION
This is a redux of #731 which was put on hold until a need for width awareness was found. I'd say this is a decent justification for bringing it back 

**Wrapping strings with fullwidth chars** 
Here's the same string being typed before and after width awareness:
![image](https://user-images.githubusercontent.com/48132522/89469082-5b6c7480-d73e-11ea-9949-c72b08d78685.png)

![image](https://user-images.githubusercontent.com/48132522/89469114-67583680-d73e-11ea-865b-0dbf1e4ee645.png)

**New method to fix cursor position:**
When we put a 2-column character at the end of the line where there's only 1 column of room, curtsies adds a padding character (space) so we can kick it down to the line below. Therefore, in order to get the right cursor position, I had to add a method that determines how many padding chars there are (`number_of_padding_chars_on_current_cursor_line`). 

Note on this method: Right now, to determine the amount of padding, it calls `display_linize`, doubling the amount of times we call that function. It's definitely possible to keep track of this as a variable in the repl class instead, or to do some changes other to ensure less redundant work is done. Feedback appreciated.

**Runtime**
One of the barriers stopping us from implementing this before was runtime . I did not find any noticeable difference when pasting, printing, or moving my cursor around large strings.