### PR TITLE
Feature: Add open close parentheses for attribute suggestions that are methods

### DIFF
--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -288,7 +288,13 @@ class MatchesIterator(object):
     def current(self):
         if self.index == -1:
             raise ValueError("No current match.")
-        return self.matches[self.index]
+        cur = self.matches[self.index]
+        return self.strip_parens(cur)
+    
+    def strip_parens(self, word):
+        if word.endswith("()"):
+            word = word[:-2]
+        return word
 
     def next(self):
         return self.__next__()


### PR DESCRIPTION
TLDR:
- Parenthesis on attribute suggestions so it's clear with attributes are methods
- Slight modification to how parentheses are autofilled


Sorry for the bad quality gifs. I should stop using GIPHY for this.

**Native function completion**
Current behavior: open parenthesis in suggestion and autofill. You have to type something after the paren before you can see the method signature.
![now](https://i.imgur.com/9swR2oO.gif)
My proposal: open AND close parens in suggestion, no parens in autofill. Now typing the open paren shows the method signature.
![new](https://i.imgur.com/LpyEVkg.gif)
This might mess with some people's muscle memory since it changes what's autofilled.


**Attributute completion**
Current behavior: no parens in suggestion or autofill. You can't tell what is a method or otherwise.
![old](https://i.imgur.com/70SszPB.gif)
My proposal: open close parens in suggestion, no parens in autofill. Very clear which attrs are methods.
![old](https://i.imgur.com/tXG1OcL.gif)
Since this only changes the infobox, it shouldn't mess with anyone's muscle memory.





If this seems worth implementing, I'll need to fix some tests. Right now, tests expect matches that look like "math.cos" or "any(", but they'll be getting matches that look like "math.cos()" and "any()". 

Also I'm not sure if I implemented this the best way. The way I did it, the actual match string is altered to have parens. Maybe it's better to leave the match as-is, but add parenthesis only on the front end. This would require some passing around of information. Feedback appreciated.