### PR TITLE
small refactor to s_hist

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -967,7 +967,8 @@ class CLIRepl(repl.Repl):
             return ""
 
         elif key in key_dispatch[config.clear_screen_key]:
-            self.s_hist = [self.s_hist[-1]]
+            # clear all but current line
+            self.screen_hist = [self.screen_hist[-1]]
             self.highlighted_paren = None
             self.redraw()
             return ""
@@ -1099,7 +1100,7 @@ class CLIRepl(repl.Repl):
                 self.stdout_hist += self.ps1
             else:
                 self.stdout_hist += self.ps1.encode(getpreferredencoding())
-            self.s_hist.append(
+            self.screen_hist.append(
                 "\x01%s\x03%s\x04"
                 % (self.config.color_scheme["prompt"], self.ps1)
             )
@@ -1110,7 +1111,7 @@ class CLIRepl(repl.Repl):
                 self.stdout_hist += self.ps2
             else:
                 self.stdout_hist += self.ps2.encode(getpreferredencoding())
-            self.s_hist.append(
+            self.screen_hist.append(
                 "\x01%s\x03%s\x04" % (prompt_more_color, self.ps2)
             )
 
@@ -1128,15 +1129,15 @@ class CLIRepl(repl.Repl):
             curses.raw(True)
 
     def redraw(self):
-        """Redraw the screen."""
+        """Redraw the screen using screen_hist"""
         self.scr.erase()
-        for k, s in enumerate(self.s_hist):
+        for k, s in enumerate(self.screen_hist):
             if not s:
                 continue
             self.iy, self.ix = self.scr.getyx()
             for i in s.split("\x04"):
                 self.echo(i, redraw=False)
-            if k < len(self.s_hist) - 1:
+            if k < len(self.screen_hist) - 1:
                 self.scr.addstr("\n")
         self.iy, self.ix = self.scr.getyx()
         self.print_line(self.s)
@@ -1175,7 +1176,7 @@ class CLIRepl(repl.Repl):
                 return self.exit_value
 
             self.history.append(inp)
-            self.s_hist[-1] += self.f_string
+            self.screen_hist[-1] += self.f_string
             if py3:
                 self.stdout_hist += inp + "\n"
             else:
@@ -1234,7 +1235,7 @@ class CLIRepl(repl.Repl):
         self.f_string = ""
         self.buffer = []
         self.scr.erase()
-        self.s_hist = []
+        self.screen_hist = []
         # Set cursor position to -1 to prevent paren matching
         self.cpos = -1
 
@@ -1247,7 +1248,7 @@ class CLIRepl(repl.Repl):
             else:
                 self.stdout_hist += line.encode(getpreferredencoding()) + "\n"
             self.print_line(line)
-            self.s_hist[-1] += self.f_string
+            self.screen_hist[-1] += self.f_string
             # I decided it was easier to just do this manually
             # than to make the print_line and history stuff more flexible.
             self.scr.addstr("\n")
@@ -1288,7 +1289,7 @@ class CLIRepl(repl.Repl):
             self.stdout_hist += t
 
         self.echo(s)
-        self.s_hist.append(s.rstrip())
+        self.screen_hist.append(s.rstrip())
 
     def show_list(
         self, items, arg_pos, topline=None, formatter=None, current_item=None
@@ -1551,7 +1552,7 @@ class CLIRepl(repl.Repl):
                 self.stdout_hist += line.encode(getpreferredencoding()) + "\n"
             self.history.append(line)
             self.print_line(line)
-            self.s_hist[-1] += self.f_string
+            self.screen_hist[-1] += self.f_string
             self.scr.addstr("\n")
             self.more = self.push(line)
             self.prompt(self.more)

--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -447,7 +447,9 @@ class Repl(object):
         self.rl_history = History(
             duplicates=config.hist_duplicates, hist_size=config.hist_length
         )
-        self.s_hist = []
+        # all input and output, stored as old style format strings
+        # (\x01, \x02, ...) for cli.py
+        self.screen_hist = []
         self.history = []  # commands executed since beginning of session
         self.redo_stack = []
         self.evaluating = False

--- a/bpython/urwid.py
+++ b/bpython/urwid.py
@@ -908,7 +908,6 @@ class URWIDRepl(repl.Repl):
         self.f_string = ""
         self.buffer = []
         self.scr.erase()
-        self.s_hist = []
         # Set cursor position to -1 to prevent paren matching
         self.cpos = -1
 
@@ -923,7 +922,6 @@ class URWIDRepl(repl.Repl):
                     line.encode(locale.getpreferredencoding()) + "\n"
                 )
             self.print_line(line)
-            self.s_hist[-1] += self.f_string
             # I decided it was easier to just do this manually
             # than to make the print_line and history stuff more flexible.
             self.scr.addstr("\n")
@@ -964,7 +962,6 @@ class URWIDRepl(repl.Repl):
             self.stdout_hist += t
 
         self.echo(s)
-        self.s_hist.append(s.rstrip())
 
     def push(self, s, insert_into_history=True):
         # Restore the original SIGINT handler. This is needed to be able
@@ -1013,7 +1010,6 @@ class URWIDRepl(repl.Repl):
         self.current_output = None
         # XXX is this the right place?
         self.rl_history.reset()
-        # XXX what is s_hist?
 
         # We need the caption to use unicode as urwid normalizes later
         # input to be the same type, using ascii as encoding. If the
@@ -1074,7 +1070,6 @@ class URWIDRepl(repl.Repl):
             inp = self.edit.get_edit_text()
             self.history.append(inp)
             self.edit.make_readonly()
-            # XXX what is this s_hist thing?
             if py3:
                 self.stdout_hist += inp
             else:


### PR DESCRIPTION
Via issue #811, it was unclear what exactly s_hist is and where it's used. As I mention in that thread, s_hist stores inputs and outputs formatted as old formatstrings (with \x01 \x02 \x03 and \x04). It's used by cli.py to recreate the screen on screen resize.

With this PR, I
- rename s_hist to screen_hist to be more clear about it's purpose (is this fine?)
- added some comments to clarify things
- remove unused modifications to s_hist in urwid.py