### PR TITLE
Fix invalid escape sequences.

### DIFF
--- a/bpython/cli.py
+++ b/bpython/cli.py
@@ -939,11 +939,11 @@ class CLIRepl(repl.Repl):
             # Redraw (as there might have been highlighted parens)
             self.print_line(self.s)
 
-        elif key in ("KEY_NPAGE", "\T"):  # page_down or \T
+        elif key in ("KEY_NPAGE"):  # page_down
             self.hend()
             self.print_line(self.s)
 
-        elif key in ("KEY_PPAGE", "\S"):  # page_up or \S
+        elif key in ("KEY_PPAGE"):  # page_up
             self.hbegin()
             self.print_line(self.s)
 

--- a/bpython/line.py
+++ b/bpython/line.py
@@ -190,7 +190,7 @@ def current_import(cursor_offset, line):
             return LinePart(start, end, m.group(1))
 
 
-current_method_definition_name_re = LazyReCompile("def\s+([a-zA-Z_][\w]*)")
+current_method_definition_name_re = LazyReCompile(r"def\s+([a-zA-Z_][\w]*)")
 
 
 def current_method_definition_name(cursor_offset, line):


### PR DESCRIPTION
Two of these come from 0259cf8 and I'm not sure what the original intent was of checking for a curses key code like "\S" or "\T". I'm guessing they should be ^S and ^T, but ^S is usually already used for save. I'm going to remove these.