### PR TITLE
upgrading curtsies version to include changes from PR 111 to fix typing bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pygments
-curtsies >=0.3.2
+curtsies >=0.3.3
 greenlet
 requests
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Pygments
-curtsies >=0.3.0
+curtsies >=0.3.2
 greenlet
 requests
 setuptools


### PR DESCRIPTION
https://github.com/bpython/curtsies/pull/111 fixed an issue that causes a crash in mypy, but bpython isn't guaranteed to use a version of curtsies that includes this fix. this diff upgrades the bpython dependency on curtsies to 0.3.3, the latest release.

i couldn't find a contributing.md or similar to show how to build and test the diff, or with any other guidelines for contributors, so if there are additional steps i should take before this is shippable, please let me know!