### PR TITLE
Docs state wrong default config file directory

### DIFF
--- a/doc/sphinx/source/configuration.rst
+++ b/doc/sphinx/source/configuration.rst
@@ -4,7 +4,7 @@ Configuration
 =============
 You can edit the config file by pressing F3 (default). If a config file does not
 exist you will asked if you would like to create a file. By default it will be
-saved to ``$XDG_CONFIG_HOME/.config/bpython/config`` [#f1]_.
+saved to ``$XDG_CONFIG_HOME/bpython/config`` [#f1]_.
 
 .. include:: configuration-options.rst
 


### PR DESCRIPTION
Fixing correct default directory for bpython config file (especially useful for color customization).