### PR TITLE
Use kwarg for request_undo_callback to fix undo.

### DIFF
--- a/bpython/curtsies.py
+++ b/bpython/curtsies.py
@@ -74,7 +74,7 @@ class FullCurtsiesRepl(BaseRepl):
         return self._interrupting_refresh_callback()
 
     def request_undo(self, n=1):
-        return self._request_undo_callback(n)
+        return self._request_undo_callback(n=n)
 
     def get_term_hw(self):
         return self.window.get_term_hw()


### PR DESCRIPTION
Not undo!

```
TypeError: callback() takes 0 positional arguments but 1 was given
```

![image](https://user-images.githubusercontent.com/458879/134779995-b42f24cc-ba54-4afd-829c-9b9c1f83cb86.png)
