### PR TITLE
disable some tests for pypy

### DIFF
--- a/bpython/test/test_inspection.py
+++ b/bpython/test/test_inspection.py
@@ -1,10 +1,13 @@
 import os
+import sys
 import unittest
 
 from bpython import inspection
 from bpython.test.fodder import encoding_ascii
 from bpython.test.fodder import encoding_latin1
 from bpython.test.fodder import encoding_utf8
+
+pypy = "PyPy" in sys.version
 
 try:
     import numpy
@@ -118,6 +121,7 @@ class TestInspection(unittest.TestCase):
         )
         self.assertEqual(encoding, "utf-8")
 
+    @unittest.skipIf(pypy, "pypy builtin signatures aren't complete")
     def test_getfuncprops_print(self):
         props = inspection.getfuncprops("print", print)
 

--- a/bpython/test/test_interpreter.py
+++ b/bpython/test/test_interpreter.py
@@ -53,7 +53,7 @@ class TestInterpreter(unittest.TestCase):
                 + green('"<input>"')
                 + ", line "
                 + bold(magenta("1"))
-                + "\n    1.1.1.1\n      ^\n"
+                + "\n    1.1.1.1\n       ^\n"
                 + bold(red("SyntaxError"))
                 + ": "
                 + cyan("invalid syntax")

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -157,7 +157,8 @@ class TestArgspec(unittest.TestCase):
     def test_func_name(self):
         for (line, expected_name) in [
             ("spam(", "spam"),
-            ("spam(map([]", "map"),
+            # map pydoc has no signature in pypy
+            ("spam(any([]", "any") if pypy else ("spam(map([]", "map"),
             ("spam((), ", "spam"),
         ]:
             self.set_input_line(line)
@@ -167,7 +168,8 @@ class TestArgspec(unittest.TestCase):
     def test_func_name_method_issue_479(self):
         for (line, expected_name) in [
             ("o.spam(", "spam"),
-            ("o.spam(map([]", "map"),
+            # map pydoc has no signature in pypy
+            ("o.spam(any([]", "any") if pypy else ("o.spam(map([]", "map"),
             ("o.spam((), ", "spam"),
         ]:
             self.set_input_line(line)
@@ -200,6 +202,7 @@ class TestArgspec(unittest.TestCase):
         # Argument position
         self.assertEqual(self.repl.arg_pos, 1)
 
+    @unittest.skipIf(pypy, "range pydoc has no signature in pypy")
     def test_issue127(self):
         self.set_input_line("x=range(")
         self.assertTrue(self.repl.get_args())


### PR DESCRIPTION
Get pypy green again so we notice if something new breaks, by
- updating position of a ^ in a syntax error
- not using `range()` or `map()` for completion tests because pypy lacks signatures in its pydoc for some builtins, including these two