### PR TITLE
Fix advanced class completion

### DIFF
--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -601,8 +601,6 @@ class Repl:
             if inspect.isclass(f):
                 class_f = None
 
-                if hasattr(f, "__init__") and f.__init__ is not object.__init__:
-                    class_f = f.__init__
                 if (
                     (not class_f or not inspection.getfuncprops(func, class_f))
                     and hasattr(f, "__new__")

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -482,6 +482,34 @@ class TestRepl(unittest.TestCase):
             self.repl.matches_iter.matches, ["abc=", "abd=", "abs("]
         )
 
+    def test_parameter_advanced_on_class(self):
+        self.repl = FakeRepl(
+            {"autocomplete_mode": autocomplete.AutocompleteModes.SIMPLE}
+        )
+        self.set_input_line("TestCls(app")
+
+        code = """
+        import inspect
+
+        class TestCls:
+            # A class with boring __init__ typing
+            def __init__(self, *args, **kwargs):
+                pass
+            # But that uses super exotic typings recognized by inspect.signature
+            __signature__ = inspect.Signature([
+                inspect.Parameter("apple", inspect.Parameter.POSITIONAL_ONLY),
+                inspect.Parameter("apple2", inspect.Parameter.KEYWORD_ONLY),
+                inspect.Parameter("pinetree", inspect.Parameter.KEYWORD_ONLY),
+            ])
+        """
+        for line in code.split("\n"):
+            print(line[8:])
+            self.repl.push(line[8:])
+
+        self.assertTrue(self.repl.complete())
+        self.assertTrue(hasattr(self.repl.matches_iter, "matches"))
+        self.assertEqual(self.repl.matches_iter.matches, ["apple2=", "apple="])
+
 
 class TestCliRepl(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR removes a check that always tried to autocomplete a class using its `__init__` function.

In fact, the `inspect` module (used afterwards in https://github.com/bpython/bpython/blob/f9b21cafc87f343b861d458c3bc438b0e419c1cc/bpython/inspection.py#L286) does a much better job at finding the arguments that are actually typing a class, which aren't always the ones in `__init__`. Since at least Python 3.6, it handles `__call__`, `__new__` and `__signature__` in addition to `__init__`, so restricting the signatures to `__init__` is actually a downgrade.
See https://github.com/python/cpython/blob/2c56c97f015a7ea81719615ddcf3c745fba5b4f3/Lib/inspect.py#L2284

I'm raising this issue because our CLI requires `__signature__` to work, which is the case if you let `inspect.signature` do its job by default but not if you manually select `cls.__init__` :slightly_smiling_face: 

Note: I also doubt that the `__new__` check below is useful on modern Python versions, since `__new__` is also checked by `inspect.signature` (therefore by `inspection.getfuncprops`), but I didn't remove it in this PR.