### PR TITLE
Disable terminal default ctrl-s behavior so it can be used for save.

### DIFF
--- a/bpython/curtsies.py
+++ b/bpython/curtsies.py
@@ -60,7 +60,10 @@ class FullCurtsiesRepl(BaseRepl):
         interp: code.InteractiveInterpreter = None,
     ) -> None:
         self.input_generator = curtsies.input.Input(
-            keynames="curtsies", sigint_event=True, paste_threshold=None
+            keynames="curtsies",
+            sigint_event=True,
+            paste_threshold=None,
+            disable_terminal_start_stop=True,
         )
         self.window = curtsies.window.CursorAwareWindow(
             sys.stdout,


### PR DESCRIPTION
Solution for https://github.com/bpython/bpython/issues/638

Terminal emulators [typically "freeze" the terminal on ctrl-s and continue on ctrl-q](https://unix.stackexchange.com/questions/12107/how-to-unfreeze-after-accidentally-pressing-ctrl-s-in-a-terminal#12146). You can run `stty -ixon` in your terminal or add it to your .bashrc or similar to disable this behavior on ctrl-s. If not disabled, users of bpython can't use ctrl-s to save their session.

I think we should do the equivalent of this for users automatically. I would guess that more users are annoyed by it but never report than users that want to use scroll control in bpython. I don't think this default behavior of ctrl-s/ctrl-q is very useful in bpython, especially since our output is much slower than `python`. However ptpython [has a similar issue](https://github.com/prompt-toolkit/ptpython/blob/master/README.rst#faq) that it also chooses not to automatically fix.

Hitting F7 is a workaround that opens the current session in a text editor, from which you can save it with a new name. Saving without changing the name saves to a temporary file and re-executes the modified session.

Note that the say that [the way Curtsies implements this behavior](https://github.com/bpython/curtsies/pull/116/files) is not by turning off this terminal feature (`-ixon` and `-ixoff`) but rather by making ctrl-s and ctrl-q no longer do these things.