### PR TITLE
WIP: Adding type hints to formatter.py

### DIFF
--- a/bpython/formatter.py
+++ b/bpython/formatter.py
@@ -28,9 +28,10 @@
 # mypy: disallow_untyped_calls=True
 
 
-from typing import MutableMapping, Any, Iterable, TextIO
+from typing import MutableMapping, Iterable, TextIO, Optional
 from pygments.formatter import Formatter
 from pygments.token import (
+    _TokenType,
     Keyword,
     Name,
     Comment,
@@ -113,16 +114,20 @@ class BPythonFormatter(Formatter):
         super().__init__(**options)
 
     def format(
-        self, tokensource: Iterable[MutableMapping[Any, str]], outfile: TextIO
+        self,
+        tokensource: Iterable[MutableMapping[_TokenType, str]],
+        outfile: TextIO,
     ) -> None:
         o: str = ""
         for token, text in tokensource:
+            t: Optional[_TokenType] = token
             if text == "\n":
                 continue
 
-            while token not in self.f_strings:
-                token = token.parent
-            o += f"{self.f_strings[token]}\x03{text}\x04"
+            while t not in self.f_strings:
+                if t is not None:
+                    t = t.parent
+            o += f"{self.f_strings[t]}\x03{text}\x04"
         outfile.write(o.rstrip())
 
 

--- a/bpython/formatter.py
+++ b/bpython/formatter.py
@@ -101,9 +101,7 @@ class BPythonFormatter(Formatter):
     straightforward."""
 
     def __init__(
-        self,
-        color_scheme: MutableMapping[str, str],
-        **options: str
+        self, color_scheme: MutableMapping[str, str], **options: str
     ) -> None:
         self.f_strings = {}
         for k, v in theme_map.items():
@@ -115,9 +113,7 @@ class BPythonFormatter(Formatter):
         super().__init__(**options)
 
     def format(
-        self,
-        tokensource: Iterable[MutableMapping[Any, str]],
-        outfile: TextIO
+        self, tokensource: Iterable[MutableMapping[Any, str]], outfile: TextIO
     ) -> None:
         o: str = ""
         for token, text in tokensource:

--- a/bpython/formatter.py
+++ b/bpython/formatter.py
@@ -28,7 +28,7 @@
 # mypy: disallow_untyped_calls=True
 
 
-from typing import MutableMapping, Iterable, TextIO, Optional
+from typing import MutableMapping, Iterable, TextIO
 from pygments.formatter import Formatter
 from pygments.token import (
     _TokenType,
@@ -120,14 +120,15 @@ class BPythonFormatter(Formatter):
     ) -> None:
         o: str = ""
         for token, text in tokensource:
-            t: Optional[_TokenType] = token
             if text == "\n":
                 continue
 
-            while t not in self.f_strings:
-                if t is not None:
-                    t = t.parent
-            o += f"{self.f_strings[t]}\x03{text}\x04"
+            while token not in self.f_strings:
+                if token.parent is None:
+                    break
+                else:
+                    token = token.parent
+            o += f"{self.f_strings[token]}\x03{text}\x04"
         outfile.write(o.rstrip())
 
 

--- a/bpython/formatter.py
+++ b/bpython/formatter.py
@@ -24,7 +24,11 @@
 # Pygments really kicks ass, it made it really easy to
 # get the exact behaviour I wanted, thanks Pygments.:)
 
+# mypy: disallow_untyped_defs=True
+# mypy: disallow_untyped_calls=True
 
+
+from typing import MutableMapping, Any, Iterable, TextIO
 from pygments.formatter import Formatter
 from pygments.token import (
     Keyword,
@@ -96,7 +100,11 @@ class BPythonFormatter(Formatter):
     See the Pygments source for more info; it's pretty
     straightforward."""
 
-    def __init__(self, color_scheme, **options):
+    def __init__(
+        self,
+        color_scheme: MutableMapping[str, str],
+        **options: str
+    ) -> None:
         self.f_strings = {}
         for k, v in theme_map.items():
             self.f_strings[k] = f"\x01{color_scheme[v]}"
@@ -106,8 +114,12 @@ class BPythonFormatter(Formatter):
                 self.f_strings[k] += "I"
         super().__init__(**options)
 
-    def format(self, tokensource, outfile):
-        o = ""
+    def format(
+        self,
+        tokensource: Iterable[MutableMapping[Any, str]],
+        outfile: TextIO
+    ) -> None:
+        o: str = ""
         for token, text in tokensource:
             if text == "\n":
                 continue


### PR DESCRIPTION
Adding type hints to formatter.py.

A note on line 128.  `token = token.parent` causes some problems with mypy because `token` is type `_TokenType` while `token.parent` is `Optional[_TokenType]`

The easy solution that I used below was to type `tokensource` like so:
`tokensource: Iterable[MutableMapping[Any, str]]` 

Another approach would be something like this:
`t: Optional[_TokenType] = token`
`t = t.parent`
If we do it that way, we can type `tokensource` more accurately:
`tokensource: Iterable[MutableMapping[_TokenType, str]]`