### PR TITLE
docs: fix simple typo, blockied -> blocked

### DIFF
--- a/bpython/curtsiesfrontend/repl.py
+++ b/bpython/curtsiesfrontend/repl.py
@@ -582,7 +582,7 @@ class BaseRepl(Repl):
     def schedule_refresh(self, when: float = 0) -> None:
         """Schedule a ScheduledRefreshRequestEvent for when.
 
-        Such a event should interrupt if blockied waiting for keyboard input"""
+        Such a event should interrupt if blocked waiting for keyboard input"""
         if self.reevaluating or self.paste_mode:
             self.fake_refresh_requested = True
         else:


### PR DESCRIPTION
There is a small typo in bpython/curtsiesfrontend/repl.py.

Should read `blocked` rather than `blockied`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md