### PR TITLE
Clarify fork instructions in contributing docs

### DIFF
--- a/doc/sphinx/source/contributing.rst
+++ b/doc/sphinx/source/contributing.rst
@@ -30,7 +30,10 @@ environment with
     # necessary every time you work on bpython
     $ source bpython-dev/bin/activate
 
-Fork bpython in the GitHub web interface, then clone the repo:
+Fork bpython in the GitHub web interface. Be sure to include the tags
+in your fork by un-selecting the option to copy only the main branch.
+
+Then, clone the forked repo:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Hi! I was following the "contributing" documentation, but ran into an issue with a bad package version when setting up the project locally. I realized that `git describe --tags --first-parent` wasn't returning anything because I forked the repo without any of the tags.

<details>
<summary>For reference, here's the error I got when running `pip install -e .`</summary>

```
~/development/bpython (main*) » pip install -e .
---
Obtaining file:///home/nitant/development/bpython
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [55 lines of output]
      running egg_info
      /tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/dist.py:561: UserWarning: The version specified ('unknown') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
        warnings.warn(
      /tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_normalization.py:93: SetuptoolsDeprecationWarning: Invalid version: 'unknown'.
              !!


              ###################
              # Invalid version #
              ###################
              'unknown' is not valid according to PEP 440.

              Please make sure specify a valid version for your package.
              Also note that future releases of setuptools may halt the build process
              if an invalid version is given.


      !!

        warnings.warn(cleandoc(msg), SetuptoolsDeprecationWarning)
      Traceback (most recent call last):
        File "/home/nitant/.pyenv/versions/bpython-dev/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/nitant/.pyenv/versions/bpython-dev/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/nitant/.pyenv/versions/bpython-dev/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 132, in get_requires_for_build_editable
          return hook(config_settings)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 447, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 178, in <module>
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 108, in setup
          return distutils.core.setup(**attrs)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 1221, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_distutils/dist.py", line 987, in run_command
          cmd_obj.ensure_finalized()
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_distutils/cmd.py", line 111, in ensure_finalized
          self.finalize_options()
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 220, in finalize_options
          parsed_version = packaging.version.Version(self.egg_version)
        File "/tmp/pip-build-env-w0n2zb0j/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/version.py", line 197, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'unknown'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
</details>