### PR TITLE
Fix __signature__ support if object has a __file__

### DIFF
--- a/bpython/inspection.py
+++ b/bpython/inspection.py
@@ -289,9 +289,13 @@ def getfuncprops(func: str, f: Callable) -> Optional[FuncProps]:
         return None
     try:
         argspec = _get_argspec_from_signature(f)
-        fprops = FuncProps(
-            func, _fix_default_values(f, argspec), is_bound_method
-        )
+        try:
+            argspec = _fix_default_values(f, argspec)
+        except KeyError as ex:
+            # Parsing of the source failed. If f has a __signature__, we trust it.
+            if not hasattr(f, "__signature__"):
+                raise ex
+        fprops = FuncProps(func, argspec, is_bound_method)
     except (TypeError, KeyError, ValueError):
         argspec_pydoc = _getpydocspec(f)
         if argspec_pydoc is None:

--- a/bpython/test/test_repl.py
+++ b/bpython/test/test_repl.py
@@ -1,5 +1,6 @@
 import collections
 import inspect
+import os
 import socket
 import sys
 import tempfile
@@ -523,13 +524,19 @@ class TestRepl(unittest.TestCase):
                 inspect.Parameter("pinetree", inspect.Parameter.KEYWORD_ONLY),
             ])
         """
-        for line in code.split("\n"):
-            print(line[8:])
-            self.repl.push(line[8:])
+        code = [x[8:] for x in code.split("\n")]
+        for line in code:
+            self.repl.push(line)
 
-        self.assertTrue(self.repl.complete())
-        self.assertTrue(hasattr(self.repl.matches_iter, "matches"))
-        self.assertEqual(self.repl.matches_iter.matches, ["apple2=", "apple="])
+        with mock.patch(
+            "bpython.inspection.inspect.getsourcelines",
+            return_value=(code, None),
+        ):
+            self.assertTrue(self.repl.complete())
+            self.assertTrue(hasattr(self.repl.matches_iter, "matches"))
+            self.assertEqual(
+                self.repl.matches_iter.matches, ["apple2=", "apple="]
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Followup to https://github.com/bpython/bpython/pull/932. I missed an edge-case :(

If a class uses exotic `__signature__` typings, but also has a `__file__` (that `inspect.getsourcelines` finds), then it is ignored whenever `_fix_default_values` doesn't work. In this case it should just 'trust' the `__signature__`.