### PR TITLE
Explicitly set README content type

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = bpython
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 license = MIT
 license_files = LICENSE
 author = Bob Farrell, Andreas Stuehrk, Sebastian Ramacher, Thomas Ballinger, et al.


### PR DESCRIPTION
The README, being a reStructuredText document, is not rendered as such on PyPI, just as plaintext – at least for releases [0.24](https://pypi.org/project/bpython/0.24/) and [0.23](https://pypi.org/project/bpython/0.23/), but not [0.22](https://pypi.org/project/bpython/0.22/).

I don't know exactly why that is; I *think* the default should already be reStructuredText. Maybe it's an older version of setuptools being used; or that all of `pyproject.toml`, `setup.cfg`, and `setup.py` are present and that results in some issue.

But given that `setup.cfg` is the one that is really considered, this change *should* fix that.