### PR TITLE
Improve autocompletion of parameters

### DIFF
--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -604,7 +604,12 @@ class ParameterNameCompletion(BaseCompletionType):
         return matches if matches else None
 
     def locate(self, cursor_offset: int, line: str) -> Optional[LinePart]:
-        return lineparts.current_word(cursor_offset, line)
+        r = lineparts.current_word(cursor_offset, line)
+        if r and r.word[-1] == "(":
+            # if the word ends with a (, it's the parent word with an empty
+            # param. Return an empty word
+            return lineparts.LinePart(r.stop, r.stop, "")
+        return r
 
 
 class ExpressionAttributeCompletion(AttrCompletion):

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -747,6 +747,16 @@ def get_completer(
             double underscore methods like __len__ in method signatures
     """
 
+    def _cmpl_sort(x: str) -> Tuple[Any, ...]:
+        """
+        Function used to sort the matches.
+        """
+        # put parameters above everything in completion
+        return (
+            x[-1] != "=",
+            x,
+        )
+
     for completer in completers:
         try:
             matches = completer.matches(
@@ -765,7 +775,9 @@ def get_completer(
             )
             continue
         if matches is not None:
-            return sorted(matches), (completer if matches else None)
+            return sorted(matches, key=_cmpl_sort), (
+                completer if matches else None
+            )
 
     return [], None
 

--- a/bpython/autocomplete.py
+++ b/bpython/autocomplete.py
@@ -747,7 +747,7 @@ def get_completer(
             double underscore methods like __len__ in method signatures
     """
 
-    def _cmpl_sort(x: str) -> Tuple[Any, ...]:
+    def _cmpl_sort(x: str) -> Tuple[bool, ...]:
         """
         Function used to sort the matches.
         """

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -106,6 +106,15 @@ class TestCumulativeCompleter(unittest.TestCase):
         cumulative = autocomplete.CumulativeCompleter([a, b])
         self.assertEqual(cumulative.matches(3, "abc"), {"a", "b"})
 
+    def test_order_completer(self):
+        a = self.completer(["ax", "ab="])
+        b = self.completer(["aa"])
+        cumulative = autocomplete.CumulativeCompleter([a, b])
+        self.assertEqual(
+            autocomplete.get_completer([cumulative], 1, "a"),
+            (["ab=", "aa", "ax"], cumulative),
+        )
+
 
 class TestFilenameCompletion(unittest.TestCase):
     def setUp(self):

--- a/bpython/test/test_autocomplete.py
+++ b/bpython/test/test_autocomplete.py
@@ -435,3 +435,7 @@ class TestParameterNameCompletion(unittest.TestCase):
         self.assertSetEqual(
             com.matches(3, "car", funcprops=funcspec), {"carrot="}
         )
+        self.assertSetEqual(
+            com.matches(5, "func(", funcprops=funcspec),
+            {"apple=", "apricot=", "banana=", "carrot="},
+        )


### PR DESCRIPTION
Two minor improvements to the completion:

1. auto-completion for parameters is done without needing to pass the beggining of a parameter. To give an example:

```python
class Test:
    def __init__(self, aaa, aab, aac):
        pass
```
**with the PR**: this allows to do: `Test(` then TAB directly to select the arguments
![image](https://github.com/bpython/bpython/assets/10530980/a8a14259-d3f6-49d8-a991-365221b8bb66)

**upstream/main**: you need to do `Test(a` before completion kicks in. `Test(` gives nothing
![image](https://github.com/bpython/bpython/assets/10530980/b19394a3-ec15-4d4b-95a6-46e3df7bc6cb)

2. auto-completion results are ordered slightly differently: parameters should be prioritized when available.

**this PR:**
![image](https://github.com/bpython/bpython/assets/10530980/ff94d8de-69c7-4821-886f-04863b304740)

**upstream/main**:
![image](https://github.com/bpython/bpython/assets/10530980/10ed456d-eead-47b2-8080-e3559a01debb)