### PR TITLE
Update `setup.py` for more up-to-date/robust customisation of the `build` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >= 43",
+  "setuptools >= 62.4.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ cwcwidth
 greenlet
 pyxdg
 requests
-setuptools
+setuptools>=62.4.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 
 from setuptools import setup
-from distutils.command.build import build
+from setuptools.command.build import build
 
 try:
     from babel.messages import frontend as babel

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 
 from setuptools import setup
-from setuptools.command.build import build
+from setuptools.command.build import build as _orig_build
 
 try:
     from babel.messages import frontend as babel
@@ -120,6 +120,11 @@ if version == "unknown":
 with open(version_file, "w") as vf:
     vf.write("# Auto-generated file, do not edit!\n")
     vf.write(f'__version__ = "{version}"\n')
+
+
+class build(_orig_build):
+    # Avoid patching the original class' attribute (more robust customisation)
+    sub_commands = _orig_build.sub_commands[:]
 
 
 cmdclass = {"build": build}


### PR DESCRIPTION
Closes #1014.

This PR proposes 2 changes:

- Import `build` from setuptools (motivation in #1014)
- Avoid patching of a class attribute of a class that owned by the project (`build.sub_commands`).