### PR TITLE
Fix simplerepl demo: missing arg for BaseRepl init

### DIFF
--- a/doc/sphinx/source/simplerepl.py
+++ b/doc/sphinx/source/simplerepl.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 class SimpleRepl(BaseRepl):
     def __init__(self, config):
         self.requested_events = []
-        BaseRepl.__init__(self, config)
+        BaseRepl.__init__(self, config, window=None)
 
     def _request_refresh(self):
         self.requested_events.append(bpythonevents.RefreshRequestEvent())


### PR DESCRIPTION
Default value was dropped in 8d16a71ef404db66d2c6fae6c362640da8ae240d