### PR TITLE
More general adaptation of showsyntaxerror() to Python 3.13

### DIFF
--- a/bpython/repl.py
+++ b/bpython/repl.py
@@ -153,7 +153,7 @@ class Interpreter(code.InteractiveInterpreter):
             return super().runsource(source, filename, symbol)
 
     def showsyntaxerror(
-        self, filename: Optional[str] = None, source: Optional[str] = None
+        self, filename: Optional[str] = None, **kwargs
     ) -> None:
         """Override the regular handler, the code's copied and pasted from
         code.py, as per showtraceback, but with the syntaxerror callback called


### PR DESCRIPTION
Python 3.13's code.InteractiveInterpreter adds a new **kwargs argument to its showsyntaxerror() method. Currently, the only use of it is to send a named argument of name "source". Whilst the current adapation of repl.Interpreter is specific and should work in the short term, here is a more general solution.