### PR TITLE
Add short project description

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = bpython
+description = A fancy curses interface to the Python interactive interpreter
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 license = MIT


### PR DESCRIPTION
Should be picked up by PyPI and others.

Currently, bpython appears in PyPI search results with a description of "None".